### PR TITLE
Bruke BigDecimal for å representere penger/beløp .

### DIFF
--- a/modell/src/main/kotlin/no/nav/dagpenger/vedtak/modell/entitet/Beløp.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/vedtak/modell/entitet/Beløp.kt
@@ -2,20 +2,22 @@ package no.nav.dagpenger.vedtak.modell.entitet
 
 import java.math.BigDecimal
 
-class Beløp private constructor(verdi: Number) : Comparable<Beløp> {
+class Beløp private constructor(verdi: BigDecimal) : Comparable<Beløp> {
 
-    private val verdi: Double = verdi.toDouble()
+    private val verdi = verdi.setScale(antallDesimaler)
     companion object {
+        private val antallDesimaler = 2
         fun fra(sats: BigDecimal): Beløp {
             return Beløp(sats)
         }
 
         fun Iterable<Beløp>.summerBeløp() = sumOf { it.verdi }.beløp
 
-        val Number.beløp get() = Beløp(this)
+        val Number.beløp get() = Beløp(BigDecimal.valueOf(this.toDouble()).setScale(antallDesimaler))
+        val BigDecimal.beløp get() = Beløp(this.setScale(antallDesimaler))
     }
 
-    fun <R> reflection(block: (Double) -> R) = block(verdi)
+    fun <R> reflection(block: (BigDecimal) -> R) = block(verdi)
 
     override fun compareTo(other: Beløp): Int = verdi.compareTo(other.verdi)
     override fun equals(other: Any?) = other is Beløp && other.verdi == this.verdi
@@ -23,9 +25,8 @@ class Beløp private constructor(verdi: Number) : Comparable<Beløp> {
     infix operator fun plus(beløp: Beløp): Beløp = Beløp(this.verdi + beløp.verdi)
     infix operator fun minus(beløp: Beløp): Beløp = Beløp(this.verdi - beløp.verdi)
     infix operator fun times(beløp: Beløp): Beløp = Beløp(verdi * beløp.verdi)
-    infix operator fun times(timer: Timer): Beløp = Beløp(verdi * timer.timer) // @todo: Ikke eksponer "private" timer verdier
-    infix operator fun div(beløp: Beløp): Beløp = Beløp(verdi / beløp.verdi)
-    infix operator fun div(timer: Timer): Beløp = Beløp(verdi / timer.timer) // @todo: Ikke eksponer "private" timer verdier
-    internal infix operator fun times(faktor: Number): Beløp = Beløp(verdi * faktor.toDouble())
+    infix operator fun div(beløp: Beløp): Beløp = Beløp((verdi / beløp.verdi).setScale(antallDesimaler))
+    infix operator fun div(timer: Timer): Beløp = this / timer.timer.beløp // @todo: Ikke eksponer "private" timer verdier
+    internal infix operator fun times(faktor: Number): Beløp = Beløp(this.verdi * BigDecimal.valueOf(faktor.toDouble()))
     override fun toString(): String = verdi.toString()
 }

--- a/modell/src/main/kotlin/no/nav/dagpenger/vedtak/modell/vedtak/VedtakFattetVisitor.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/vedtak/modell/vedtak/VedtakFattetVisitor.kt
@@ -66,7 +66,7 @@ internal class VedtakFattetVisitor : VedtakVisitor {
             utbetalingsdager = rettighetsdager.map { løpendeRettighetDag ->
                 UtbetalingsdagDto(
                     dato = løpendeRettighetDag.dato,
-                    beløp = løpendeRettighetDag.beløp.reflection { it },
+                    beløp = løpendeRettighetDag.beløp.reflection { it }.toDouble(),
                 )
             },
             utfall = when (utfall) {


### PR DESCRIPTION
BigDecimal gir bedre presisjon ved beregning. Double og Float kan føre til føre til avrundingsfeil og unøyaktigheter i beregninger. Feks

```
val amount1: Double = 0.1
val amount2: Double = 0.2
val sum: Double = amount1 + amount2
println(sum) // Output: 0.30000000000000004
```

```
import java.math.BigDecimal

val amount1: BigDecimal = BigDecimal("0.1")
val amount2: BigDecimal = BigDecimal("0.2")
val sum: BigDecimal = amount1.add(amount2)
println(sum) // Output: 0.3
```