### PR TITLE
fjerner comparable

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/OpplysningSvarBygger.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/OpplysningSvarBygger.kt
@@ -14,7 +14,7 @@ import no.nav.dagpenger.regel.Behov.Barnetillegg
 import no.nav.dagpenger.regel.Behov.BarnetilleggV2
 import java.util.UUID
 
-class OpplysningSvarBygger<T : Comparable<T>>(
+class OpplysningSvarBygger<T : Any>(
     private val type: Opplysningstype<T>,
     private val verdi: VerdiMapper,
     private val kilde: Kilde,
@@ -33,7 +33,7 @@ class OpplysningSvarBygger<T : Comparable<T>>(
         )
 
     interface VerdiMapper {
-        fun <T : Comparable<T>> map(datatype: Datatype<T>): T
+        fun <T : Any> map(datatype: Datatype<T>): T
     }
 }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApi.kt
@@ -723,7 +723,7 @@ private val OtelTraceIdPlugin =
 private class HttpVerdiMapper(
     private val nyOpplysning: NyOpplysningDTO,
 ) : VerdiMapper {
-    override fun <T : Comparable<T>> map(datatype: Datatype<T>): T =
+    override fun <T : Any> map(datatype: Datatype<T>): T =
         when (datatype) {
             Heltall -> nyOpplysning.verdi.toInt() as T
             Boolsk -> nyOpplysning.verdi.toBoolean() as T

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/OpplysningSvarMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/OpplysningSvarMottak.kt
@@ -122,7 +122,7 @@ internal class OpplysningSvarMottak(
 
 internal class OpplysningSvarMessage(
     private val packet: JsonMessage,
-    private val opplysningstyper: Set<Opplysningstype<*>>,
+    private val opplysningstyper: Set<Opplysningstype<out Any>>,
 ) : KafkaMelding(packet) {
     private val hendelse
         get() =
@@ -278,7 +278,7 @@ private class JsonMapper(
     private val typeNavn: String,
     private val verdi: JsonNode,
 ) : OpplysningSvarBygger.VerdiMapper {
-    override fun <T : Comparable<T>> map(datatype: Datatype<T>): T =
+    override fun <T : Any> map(datatype: Datatype<T>): T =
         when (datatype) {
             Dato -> {
                 verdi.asLocalDate() as T

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgres.kt
@@ -135,7 +135,7 @@ class OpplysningerRepositoryPostgres : OpplysningerRepository {
         private val session: Session,
         private val kildeRespository: KildeRepository = kildeRepository,
     ) {
-        fun hentOpplysninger(opplysningerIder: Set<UUID>): Map<UUID, List<Opplysning<*>>> {
+        fun hentOpplysninger(opplysningerIder: Set<UUID>): Map<UUID, List<Opplysning<out Any>>> {
             val rader: Set<OpplysningRad<*>> =
                 session
                     .run(
@@ -195,7 +195,7 @@ class OpplysningerRepositoryPostgres : OpplysningerRepository {
                 .groupBy { opplysningerIdForOpplysning.getValue(it.id) }
         }
 
-        private fun <T : Comparable<T>> Row.somOpplysningRad(datatype: Datatype<T>): OpplysningRad<T> {
+        private fun <T : Any> Row.somOpplysningRad(datatype: Datatype<T>): OpplysningRad<T> {
             val opplysingerId = uuid("opplysninger_id")
             val id = uuid("id")
             val typeUuid = uuid("type_uuid")
@@ -256,7 +256,7 @@ class OpplysningerRepositoryPostgres : OpplysningerRepository {
         }
 
         @Suppress("UNCHECKED_CAST")
-        private fun <T : Comparable<T>> Datatype<T>.verdi(row: Row): T =
+        private fun <T : Any> Datatype<T>.verdi(row: Row): T =
             when (this) {
                 Boolsk -> {
                     row.boolean("verdi_boolsk")
@@ -521,18 +521,18 @@ class OpplysningerRepositoryPostgres : OpplysningerRepository {
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun Collection<OpplysningRad<*>>.somOpplysninger(): List<Opplysning<*>> {
-    val opplysningMap = mutableMapOf<UUID, Opplysning<*>>()
+private fun Collection<OpplysningRad<out Any>>.somOpplysninger(): List<Opplysning<out Any>> {
+    val opplysningMap = mutableMapOf<UUID, Opplysning<out Any>>()
 
     // Finn opplysningen som erstattes av denne
-    fun <T : Comparable<T>> OpplysningRad<T>.finnErstatter() {
+    fun <T : Any> OpplysningRad<T>.finnErstatter() {
         this.erstatter?.let {
             require(opplysningMap.contains(it)) { "Opplysning ${this.id} trenger id $it er ikke funnet" }
             (opplysningMap[this.id] as Opplysning<T>).erstatter(opplysningMap[it] as Opplysning<T>)
         }
     }
 
-    fun <T : Comparable<T>> OpplysningRad<T>.toOpplysning(): Opplysning<*> {
+    fun <T : Any> OpplysningRad<T>.toOpplysning(): Opplysning<out Any> {
         // If the Opplysning instance has already been created, return it
         opplysningMap[id]?.let { return it }
 
@@ -600,7 +600,7 @@ private data class UtledningRad(
     val versjon: String? = null,
 )
 
-private data class OpplysningRad<T : Comparable<T>>(
+private data class OpplysningRad<T : Any>(
     val opplysingerId: UUID,
     val id: UUID,
     val opplysningstype: Opplysningstype<T>,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/TestSaksbehandler2.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/TestSaksbehandler2.kt
@@ -120,7 +120,7 @@ internal class TestSaksbehandler2(
         return behandling.shouldNotBeNull()
     }
 
-    fun <T : Comparable<T>> endreOpplysning(
+    fun <T : Any> endreOpplysning(
         opplysningstype: Opplysningstype<T>,
         verdi: T,
         begrunnelse: String = "",

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingsresultatTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingsresultatTest.kt
@@ -181,7 +181,7 @@ class BehandlingsresultatTest {
         godkjennJSON(klump)
     }
 
-    private fun <T : Comparable<T>> Opplysningstype<T>.periode(
+    private fun <T : Any> Opplysningstype<T>.periode(
         fraOgMed: LocalDate,
         tilOgMed: LocalDate? = null,
         vurdering: T,

--- a/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/hendelser/OpplysningSvarHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/hendelser/OpplysningSvarHendelse.kt
@@ -32,7 +32,7 @@ class OpplysningSvarHendelse(
         )
 }
 
-data class OpplysningSvar<T : Comparable<T>>(
+data class OpplysningSvar<T : Any>(
     val opplysningstype: Opplysningstype<T>,
     val verdi: T,
     val tilstand: Tilstand,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Datatype.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Datatype.kt
@@ -7,11 +7,11 @@ import no.nav.dagpenger.opplysning.verdier.Periode
 import no.nav.dagpenger.opplysning.verdier.Ulid
 import java.time.LocalDate
 
-sealed class Datatype<T : Comparable<T>>(
+sealed class Datatype<T>(
     val klasse: Class<T>,
 ) {
     companion object {
-        fun fromString(datatype: String): Datatype<*> =
+        fun fromString(datatype: String): Datatype<out Any> =
             when (datatype) {
                 "Dato" -> Dato
                 "Desimaltall" -> Desimaltall

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Forretningsprosess.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Forretningsprosess.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.opplysning
 
+import no.nav.dagpenger.opplysning.regel.Regel
 import java.time.LocalDate
 
 abstract class Forretningsprosess(
@@ -34,11 +35,12 @@ abstract class Forretningsprosess(
     open fun produsenter(
         regelverksdato: LocalDate,
         opplysningerPåPrøvingsdato: LesbarOpplysninger,
-    ) = regelverk.regelsett
-        .filter { it.skalKjøres(opplysningerPåPrøvingsdato) }
-        .filter { it.skalRevurderes(opplysningerPåPrøvingsdato) }
-        .flatMap { it.regler(regelverksdato) }
-        .associateBy { it.produserer }
+    ): Map<Opplysningstype<out Any>, Regel<*>> =
+        regelverk.regelsett
+            .filter { it.skalKjøres(opplysningerPåPrøvingsdato) }
+            .filter { it.skalRevurderes(opplysningerPåPrøvingsdato) }
+            .flatMap { it.regler(regelverksdato) }
+            .associateBy { it.produserer }
 }
 
 interface ProsessPlugin {

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/LesbarOpplysninger.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/LesbarOpplysninger.kt
@@ -8,19 +8,19 @@ interface LesbarOpplysninger {
 
     val kunEgne: Opplysninger
 
-    fun <T : Comparable<T>> finnOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>
+    fun <T : Any> finnOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>
 
-    fun <T : Comparable<T>> finnNullableOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>?
+    fun <T : Any> finnNullableOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>?
 
-    fun har(opplysningstype: Opplysningstype<*>): Boolean
+    fun <T : Any> har(opplysningstype: Opplysningstype<T>): Boolean
 
-    fun mangler(opplysningstype: Opplysningstype<*>): Boolean = !har(opplysningstype)
+    fun <T : Any> mangler(opplysningstype: Opplysningstype<T>): Boolean = !har(opplysningstype)
 
     fun finnFlere(opplysningstyper: List<Opplysningstype<*>>): List<Opplysning<*>>
 
-    fun <T : Comparable<T>> finnAlle(opplysningstyper: List<Opplysningstype<T>>): List<Opplysning<T>>
+    fun <T : Any> finnAlle(opplysningstyper: List<Opplysningstype<T>>): List<Opplysning<T>>
 
-    fun <T : Comparable<T>> finnAlle(opplysningstype: Opplysningstype<T>): List<Opplysning<T>>
+    fun <T : Any> finnAlle(opplysningstype: Opplysningstype<T>): List<Opplysning<T>>
 
     fun finnOpplysning(opplysningId: UUID): Opplysning<*>
 

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/LesbarOpplysningerMedLogg.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/LesbarOpplysningerMedLogg.kt
@@ -17,12 +17,12 @@ class LesbarOpplysningerMedLogg(
             oppslag.maxOfOrNull { it.opprettet }
                 ?: throw IllegalStateException("Ingen opplysninger har blitt brukt")
 
-    override fun <T : Comparable<T>> finnOpplysning(opplysningstype: Opplysningstype<T>) =
+    override fun <T : Any> finnOpplysning(opplysningstype: Opplysningstype<T>) =
         opplysninger.finnOpplysning(opplysningstype).apply {
             oppslag.add(this)
         }
 
-    override fun <T : Comparable<T>> finnNullableOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>? =
+    override fun <T : Any> finnNullableOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>? =
         opplysninger.finnNullableOpplysning(opplysningstype)?.apply {
             oppslag.add(this)
         }
@@ -32,7 +32,7 @@ class LesbarOpplysningerMedLogg(
             oppslag.add(this)
         }
 
-    override fun har(opplysningstype: Opplysningstype<*>) =
+    override fun <T : Any> har(opplysningstype: Opplysningstype<T>) =
         opplysninger.har(opplysningstype).also { harOpplysning ->
             if (harOpplysning) {
                 oppslag.add(opplysninger.finnOpplysning(opplysningstype))
@@ -48,9 +48,9 @@ class LesbarOpplysningerMedLogg(
 
     override fun finnFlere(opplysningstyper: List<Opplysningstype<*>>) = TODO("Not yet implemented")
 
-    override fun <T : Comparable<T>> finnAlle(opplysningstyper: List<Opplysningstype<T>>) = TODO("Not yet implemented")
+    override fun <T : Any> finnAlle(opplysningstyper: List<Opplysningstype<T>>) = TODO("Not yet implemented")
 
-    override fun <T : Comparable<T>> finnAlle(opplysningstype: Opplysningstype<T>) = TODO("Not yet implemented")
+    override fun <T : Any> finnAlle(opplysningstype: Opplysningstype<T>) = TODO("Not yet implemented")
 
     override fun erErstattet(opplysninger: List<Opplysning<*>>) = TODO("Not yet implemented")
 

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysning.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysning.kt
@@ -14,7 +14,7 @@ data class Utledning(
     internal constructor(regel: Regel<*>, opplysninger: List<Opplysning<*>>) : this(regel::class.java.simpleName, opplysninger)
 }
 
-sealed class Opplysning<T : Comparable<T>>(
+sealed class Opplysning<T : Any>(
     val id: UUID,
     val opplysningstype: Opplysningstype<T>,
     val verdi: T,
@@ -59,7 +59,7 @@ sealed class Opplysning<T : Comparable<T>>(
     abstract fun lagForkortet(framTil: Opplysning<*>): Opplysning<T>
 }
 
-class Hypotese<T : Comparable<T>>(
+class Hypotese<T : Any>(
     id: UUID,
     opplysningstype: Opplysningstype<T>,
     verdi: T,
@@ -98,7 +98,7 @@ class Hypotese<T : Comparable<T>>(
     }
 }
 
-class Faktum<T : Comparable<T>>(
+class Faktum<T : Any>(
     id: UUID,
     opplysningstype: Opplysningstype<T>,
     verdi: T,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysninger.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysninger.kt
@@ -3,7 +3,6 @@ package no.nav.dagpenger.opplysning
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.dagpenger.opplysning.LesbarOpplysninger.Filter
 import no.nav.dagpenger.opplysning.Opplysning.Companion.gyldigeFor
-import no.nav.dagpenger.opplysning.Opplysninger.Companion.logger
 import no.nav.dagpenger.uuid.UUIDv7
 import java.time.LocalDate
 import java.util.UUID
@@ -35,7 +34,7 @@ class Opplysninger private constructor(
         alleOpplysningerMap = alleOpplysninger.groupBy { it.opplysningstype }
     }
 
-    fun <T : Comparable<T>> leggTil(opplysning: Opplysning<T>) {
+    fun <T : Any> leggTil(opplysning: Opplysning<T>) {
         val eksisterende = finnNullableOpplysning(opplysning.opplysningstype, opplysning.gyldighetsperiode)
 
         if (eksisterende != null) {
@@ -71,27 +70,26 @@ class Opplysninger private constructor(
 
     override fun erErstattet(opplysninger: List<Opplysning<*>>) = opplysninger.any { it.id in erstattet }
 
-    internal fun <T : Comparable<T>> leggTilUtledet(opplysning: Opplysning<T>) = leggTil(opplysning)
+    internal fun <T : Any> leggTilUtledet(opplysning: Opplysning<T>) = leggTil(opplysning)
 
-    override fun <T : Comparable<T>> finnOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T> =
+    override fun <T : Any> finnOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T> =
         finnNullableOpplysning(opplysningstype) ?: throw IllegalStateException("Har ikke opplysning $opplysningstype som er gyldig")
 
-    override fun <T : Comparable<T>> finnNullableOpplysning(opplysningstype: Opplysningstype<T>) =
+    override fun <T : Any> finnNullableOpplysning(opplysningstype: Opplysningstype<T>) =
         finnNullableOpplysning(opplysningstype, Gyldighetsperiode())
 
     override fun finnOpplysning(opplysningId: UUID) =
         alleOpplysninger.lastOrNull { it.id == opplysningId }
             ?: throw OpplysningIkkeFunnetException("Har ikke opplysning med id=$opplysningId")
 
-    override fun har(opplysningstype: Opplysningstype<*>) = alleOpplysninger.any { it.er(opplysningstype) }
+    override fun <T : Any> har(opplysningstype: Opplysningstype<T>) = alleOpplysninger.any { it.er(opplysningstype) }
 
     override fun finnFlere(opplysningstyper: List<Opplysningstype<*>>) =
         opplysningstyper.mapNotNull { type -> alleOpplysninger.lastOrNull { it.er(type) } }
 
-    override fun <T : Comparable<T>> finnAlle(opplysningstyper: List<Opplysningstype<T>>) =
-        opplysningstyper.flatMap { type -> finnAlle(type) }
+    override fun <T : Any> finnAlle(opplysningstyper: List<Opplysningstype<T>>) = opplysningstyper.flatMap { type -> finnAlle(type) }
 
-    override fun <T : Comparable<T>> finnAlle(opplysningstype: Opplysningstype<T>) =
+    override fun <T : Any> finnAlle(opplysningstype: Opplysningstype<T>) =
         alleOpplysninger.filter { it.er(opplysningstype) }.filterIsInstance<Opplysning<T>>()
 
     override fun forDato(gjelderFor: LocalDate): LesbarOpplysninger {
@@ -138,7 +136,7 @@ class Opplysninger private constructor(
         avhengigheter.forEach { avhengighet -> fjern(avhengighet, false) }
     }
 
-    private fun <T : Comparable<T>> finnNullableOpplysning(
+    private fun <T : Any> finnNullableOpplysning(
         opplysningstype: Opplysningstype<T>,
         gyldighetsperiode: Gyldighetsperiode = Gyldighetsperiode(),
     ): Opplysning<T>? {

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysningstype.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysningstype.kt
@@ -26,7 +26,7 @@ enum class OpplysningstypeKategori {
     Materiell,
 }
 
-class Opplysningstype<T : Comparable<T>>(
+class Opplysningstype<T : Any>(
     val id: Id<T>,
     val navn: String,
     val behovId: String,
@@ -44,7 +44,7 @@ class Opplysningstype<T : Comparable<T>>(
         definerteTyper.add(this)
     }
 
-    data class Id<T : Comparable<T>>(
+    data class Id<T>(
         val uuid: UUID,
         val datatype: Datatype<T>,
     )
@@ -175,7 +175,7 @@ class Opplysningstype<T : Comparable<T>>(
             utgåtteBehovId: Set<String> = emptySet(),
         ): Opplysningstype<BarnListe> = som(id, beskrivelse, formål, synlig, behovId, enhet = enhet, utgåtteBehovId = utgåtteBehovId)
 
-        fun <T : Comparable<T>> som(
+        fun <T : Any> som(
             id: Id<T>,
             beskrivelse: String,
             formål: Opplysningsformål = Opplysningsformål.Regel,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Regelkjøring.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Regelkjøring.kt
@@ -13,7 +13,7 @@ import java.time.LocalDate
 
 typealias Informasjonsbehov = Map<Opplysningstype<*>, Set<Opplysning<*>>>
 
-typealias Regelkart = Map<Opplysningstype<*>, Regel<*>>
+typealias Regelkart = Map<Opplysningstype<out Any>, Regel<*>>
 
 class Regelkjøring(
     private val regelverksdato: LocalDate,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/TidslinjeBygger.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/TidslinjeBygger.kt
@@ -12,7 +12,7 @@ data class PeriodisertVerdi<T>(
 
 typealias Tidslinje<T> = List<PeriodisertVerdi<T>>
 
-class TidslinjeBygger<T : Comparable<T>>(
+class TidslinjeBygger<T : Any>(
     private val opplysninger: Collection<Opplysning<T>>,
 ) {
     val sortertOpplysninger = opplysninger.sortedBy { it.gyldighetsperiode.fraOgMed }

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/dsl/RegelsettBuilderBase.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/dsl/RegelsettBuilderBase.kt
@@ -36,7 +36,7 @@ abstract class RegelsettBuilderBase(
         relevant = block
     }
 
-    fun <T : Comparable<T>> regel(
+    fun <T : Any> regel(
         produserer: Opplysningstype<T>,
         gjelderFraOgMed: LocalDate = LocalDate.MIN,
         block: Opplysningstype<T>.() -> Regel<*>,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/AntallAv.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/AntallAv.kt
@@ -5,7 +5,7 @@ import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.verdier.Barn
 import no.nav.dagpenger.opplysning.verdier.BarnListe
 
-class AntallAv<T : Comparable<T>>(
+class AntallAv<T : Any>(
     produserer: Opplysningstype<Int>,
     val opplysningstype: Opplysningstype<BarnListe>,
     val filter: Barn.() -> Boolean,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Brukt.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Brukt.kt
@@ -4,7 +4,7 @@ import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.verdier.Beløp
 
-class Brukt<T : Comparable<T>> internal constructor(
+class Brukt<T : Any> internal constructor(
     produserer: Opplysningstype<String>,
     private val a: Opplysningstype<T>,
 ) : Regel<String>(produserer, listOf(a)) {

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Divisjon.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Divisjon.kt
@@ -4,7 +4,7 @@ import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.verdier.Beløp
 
-class Divisjon<T : Comparable<T>> internal constructor(
+class Divisjon<T : Any> internal constructor(
     produserer: Opplysningstype<Beløp>,
     private val beløp: Opplysningstype<Beløp>,
     private val faktor: Opplysningstype<T>,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Ekstern.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Ekstern.kt
@@ -3,15 +3,15 @@ package no.nav.dagpenger.opplysning.regel
 import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysningstype
 
-class Ekstern<T : Comparable<T>> internal constructor(
+class Ekstern<T : Any> internal constructor(
     produserer: Opplysningstype<T>,
-    avhengigheter: List<Opplysningstype<*>>,
+    avhengigheter: List<Opplysningstype<out Any>>,
 ) : Regel<T>(produserer, avhengigheter) {
     override fun kjør(opplysninger: LesbarOpplysninger): T = throw IllegalStateException("Kan ikke kjøres")
 
     override fun toString() = "Henter inn opplysning for $produserer med ${avhengerAv.joinToString { it.navn }} som avhengigheter."
 }
 
-fun <T : Comparable<T>> Opplysningstype<T>.innhentMed(vararg opplysninger: Opplysningstype<*>) = Ekstern(this, opplysninger.toList())
+fun <T : Any> Opplysningstype<T>.innhentMed(vararg opplysninger: Opplysningstype<out Any>) = Ekstern(this, opplysninger.toList())
 
-val <T : Comparable<T>> Opplysningstype<T>.innhentes get() = Ekstern(this, emptyList())
+val <T : Any> Opplysningstype<T>.innhentes get() = Ekstern(this, emptyList())

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Har.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Har.kt
@@ -5,11 +5,11 @@ import no.nav.dagpenger.opplysning.Opplysningstype
 
 class Har internal constructor(
     produserer: Opplysningstype<Boolean>,
-    private val opplysningstype: Opplysningstype<*>,
+    private val opplysningstype: Opplysningstype<out Any>,
 ) : Regel<Boolean>(produserer, listOf(opplysningstype)) {
     override fun kjør(opplysninger: LesbarOpplysninger): Boolean = opplysninger.har(opplysningstype)
 
     override fun toString() = "Sjekker om vi har $opplysningstype"
 }
 
-fun Opplysningstype<Boolean>.har(opplysningstype: Opplysningstype<*>) = Har(this, opplysningstype)
+fun Opplysningstype<Boolean>.har(opplysningstype: Opplysningstype<out Any>) = Har(this, opplysningstype)

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/HvisSannMedResultat.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/HvisSannMedResultat.kt
@@ -4,7 +4,7 @@ import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.finn
 
-class HvisSannMedResultat<T : Comparable<T>>(
+class HvisSannMedResultat<T : Any>(
     produserer: Opplysningstype<T>,
     private val sjekk: Opplysningstype<Boolean>,
     private val hvisSann: Opplysningstype<T>,
@@ -13,7 +13,7 @@ class HvisSannMedResultat<T : Comparable<T>>(
     override fun lagPlan(
         opplysninger: LesbarOpplysninger,
         plan: MutableSet<Regel<*>>,
-        produsenter: Map<Opplysningstype<*>, Regel<*>>,
+        produsenter: Map<Opplysningstype<out Any>, Regel<*>>,
         besøkt: MutableSet<Regel<*>>,
     ) {
         if (besøkt.contains(this)) return else besøkt.add(this)
@@ -52,7 +52,7 @@ class HvisSannMedResultat<T : Comparable<T>>(
     override fun toString() = "Hvis $sjekk er sann, returner $hvisSann, ellers returner $hvisUsann"
 }
 
-fun <T : Comparable<T>> Opplysningstype<T>.hvisSannMedResultat(
+fun <T : Any> Opplysningstype<T>.hvisSannMedResultat(
     sjekk: Opplysningstype<Boolean>,
     hvisSann: Opplysningstype<T>,
     hvisUsann: Opplysningstype<T>,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Multiplikasjon.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Multiplikasjon.kt
@@ -4,7 +4,7 @@ import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.verdier.Beløp
 
-class Multiplikasjon<R : Comparable<R>, T1 : Comparable<T1>, T2 : Comparable<T2>> internal constructor(
+class Multiplikasjon<R : Any, T1 : Any, T2 : Any> internal constructor(
     produserer: Opplysningstype<R>,
     private val faktor1: Opplysningstype<T1>,
     private val faktor2: Opplysningstype<T2>,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Oppslag.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Oppslag.kt
@@ -4,7 +4,7 @@ import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysningstype
 import java.time.LocalDate
 
-class Oppslag<T : Comparable<T>> internal constructor(
+class Oppslag<T : Any> internal constructor(
     produserer: Opplysningstype<T>,
     private val dato: Opplysningstype<LocalDate>,
     private val block: (LocalDate) -> T,
@@ -18,7 +18,7 @@ class Oppslag<T : Comparable<T>> internal constructor(
     override fun toString() = "Finner gjeldende verdi for $produserer på $dato"
 }
 
-fun <T : Comparable<T>> Opplysningstype<T>.oppslag(
+fun <T : Any> Opplysningstype<T>.oppslag(
     dato: Opplysningstype<LocalDate>,
     block: (LocalDate) -> T,
 ) = Oppslag(this, dato, block)

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Regel.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Regel.kt
@@ -9,10 +9,10 @@ import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.Utledning
 import java.time.LocalDate
 
-abstract class Regel<T : Comparable<T>> internal constructor(
+abstract class Regel<T : Any> internal constructor(
     internal val produserer: Opplysningstype<T>,
     // todo: Bør dette være et Set? Vi er ikke avhengig av rekkefølge
-    internal val avhengerAv: List<Opplysningstype<*>> = emptyList(),
+    internal val avhengerAv: List<Opplysningstype<out Any>> = emptyList(),
 ) {
     init {
         require(avhengerAv.none { it == produserer }) {
@@ -23,7 +23,7 @@ abstract class Regel<T : Comparable<T>> internal constructor(
     internal open fun lagPlan(
         opplysninger: LesbarOpplysninger,
         plan: MutableSet<Regel<*>>,
-        produsenter: Map<Opplysningstype<*>, Regel<*>>,
+        produsenter: Map<Opplysningstype<out Any>, Regel<*>>,
         besøkt: MutableSet<Regel<*>>,
     ) {
         if (besøkt.contains(this)) return else besøkt.add(this)

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Substraksjon.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Substraksjon.kt
@@ -5,7 +5,7 @@ import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.opplysning.verdier.Beløp
 
 @Suppress("UNCHECKED_CAST")
-class Substraksjon<T : Comparable<T>> internal constructor(
+class Substraksjon<T : Any> internal constructor(
     produserer: Opplysningstype<T>,
     private vararg val opplysningstyper: Opplysningstype<T>,
     private val operasjon: (List<T>) -> T,

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/TomRegel.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/TomRegel.kt
@@ -3,14 +3,14 @@ package no.nav.dagpenger.opplysning.regel
 import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysningstype
 
-class TomRegel<T : Comparable<T>> internal constructor(
+class TomRegel<T : Any> internal constructor(
     produserer: Opplysningstype<T>,
-    avhengigheter: List<Opplysningstype<*>>,
+    avhengigheter: List<Opplysningstype<Any>>,
 ) : Regel<T>(produserer, avhengigheter) {
     override fun lagPlan(
         opplysninger: LesbarOpplysninger,
         plan: MutableSet<Regel<*>>,
-        produsenter: Map<Opplysningstype<*>, Regel<*>>,
+        produsenter: Map<Opplysningstype<out Any>, Regel<*>>,
         besøkt: MutableSet<Regel<*>>,
     ) {
         return
@@ -21,4 +21,4 @@ class TomRegel<T : Comparable<T>> internal constructor(
     override fun toString() = "Tom regel for $produserer"
 }
 
-val <T : Comparable<T>> Opplysningstype<T>.tomRegel get() = TomRegel(this, emptyList())
+val <T : Any> Opplysningstype<T>.tomRegel get() = TomRegel(this, emptyList())

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Utgangspunkt.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/Utgangspunkt.kt
@@ -3,19 +3,19 @@ package no.nav.dagpenger.opplysning.regel
 import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysningstype
 
-class Utgangspunkt<T : Comparable<T>> internal constructor(
+class Utgangspunkt<T : Any> internal constructor(
     produserer: Opplysningstype<T>,
     private val verdi: T,
-    nullstillesAv: List<Opplysningstype<*>> = emptyList(),
+    nullstillesAv: List<Opplysningstype<out Any>> = emptyList(),
 ) : Regel<T>(produserer, nullstillesAv) {
     override fun kjør(opplysninger: LesbarOpplysninger): T = verdi
 
     override fun toString() = "Bruker $verdi som utgangspunkt for $produserer"
 }
 
-fun <T : Comparable<T>> Opplysningstype<T>.somUtgangspunkt(verdi: T) = Utgangspunkt(this, verdi)
+fun <T : Any> Opplysningstype<T>.somUtgangspunkt(verdi: T) = Utgangspunkt(this, verdi)
 
-fun <T : Comparable<T>> Opplysningstype<T>.somUtgangspunkt(
+fun <T : Any> Opplysningstype<T>.somUtgangspunkt(
     verdi: T,
-    vararg nullstillesAv: Opplysningstype<*>,
+    vararg nullstillesAv: Opplysningstype<out Any>,
 ) = Utgangspunkt(this, verdi, nullstillesAv.toList())

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/dato/DagensDato.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/dato/DagensDato.kt
@@ -11,7 +11,7 @@ class DagensDato internal constructor(
     override fun lagPlan(
         opplysninger: LesbarOpplysninger,
         plan: MutableSet<Regel<*>>,
-        produsenter: Map<Opplysningstype<out Comparable<*>>, Regel<*>>,
+        produsenter: Map<Opplysningstype<out Any>, Regel<*>>,
         besøkt: MutableSet<Regel<*>>,
     ) {
         val dagensDato = LocalDate.now()

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/dato/SisteAv.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/regel/dato/SisteAv.kt
@@ -19,7 +19,7 @@ class SisteAv internal constructor(
 
 class SisteAvGyldighetsperiode internal constructor(
     produserer: Opplysningstype<LocalDate>,
-    private vararg val opplysningerTyper: Opplysningstype<*>,
+    private vararg val opplysningerTyper: Opplysningstype<Any>,
 ) : Regel<LocalDate>(produserer, opplysningerTyper.toList()) {
     override fun kjør(opplysninger: LesbarOpplysninger): LocalDate {
         val dager = opplysninger.finnFlere(opplysningerTyper.toList()).map { it.gyldighetsperiode.fraOgMed }
@@ -43,6 +43,6 @@ class SisteHeltallVerdi internal constructor(
 
 fun Opplysningstype<LocalDate>.sisteAv(vararg liste: Opplysningstype<LocalDate>) = SisteAv(this, *liste)
 
-fun Opplysningstype<LocalDate>.sisteAv(vararg liste: Opplysningstype<*>) = SisteAvGyldighetsperiode(this, *liste)
+fun Opplysningstype<LocalDate>.sisteAv(vararg liste: Opplysningstype<Any>) = SisteAvGyldighetsperiode(this, *liste)
 
 fun Opplysningstype<Int>.sisteAv(vararg liste: Opplysningstype<Int>) = SisteHeltallVerdi(this, *liste)

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/TidslinjeByggerTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/TidslinjeByggerTest.kt
@@ -96,7 +96,7 @@ class TidslinjeByggerTest {
         )
     }
 
-    private fun <T : Comparable<T>> Opplysningstype<T>.periode(
+    private fun <T : Any> Opplysningstype<T>.periode(
         fraOgMed: LocalDate,
         tilOgMed: LocalDate? = null,
         vurdering: T,


### PR DESCRIPTION
det underliggende `compareTo` virker ikke å være i bruk, og da bør vi ikke trenge å gjøre oss avhengig av det interfacet over alt.

istedenfor så kan vi endre typene til `T: Any` for å sikre oss at `T` ikke kan være null.

Det samme gjelder star projections, `* `. siden den godtar null, så må vi endre til `out Any` de stedene vi trenger det.