### PR TITLE
oppretter indeks på basert_på_behandling_id

### DIFF
--- a/mediator/src/main/resources/db/migration/V89__INDEKS_BASERT_PAA.sql
+++ b/mediator/src/main/resources/db/migration/V89__INDEKS_BASERT_PAA.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_behandling_basert_pa
+    ON behandling (basert_på_behandling_id)
+    WHERE basert_på_behandling_id IS NOT NULL;

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/PostgresMigrationTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/PostgresMigrationTest.kt
@@ -10,7 +10,7 @@ class PostgresMigrationTest {
     fun `Migration scripts are applied successfully`() {
         withCleanDb {
             val migrations = runMigration()
-            migrations shouldBeExactly 21
+            migrations shouldBeExactly 22
         }
     }
 }


### PR DESCRIPTION
når vi slår opp alle behandlinger på en ident så går vi fremover ved å joine alle behandlinger som baserer seg på forrige.

kolonnen `basert_på_behandling_id` har ikke indeks fra før, og dette gjorde utslag på query-planen med en Sequential scan:

…
 Hash Join  (actual time=88.073..90.470 rows=1 loops=11)
   Hash Cond: (r.basert_på_behandling_id = bk_1.behandling_id)
   ->  Seq Scan on behandling r  (rows=220821 loops=11)
         Buffers: shared hit=47080
…