### PR TITLE
effektiviserer spørring utenom indeksen

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgres.kt
@@ -71,17 +71,23 @@ internal class BehandlingRepositoryPostgres(
         // language=PostgreSQL
         val cte =
             """
-            with recursive behandlingkjede as (
-                -- rotbehandlinger, de som ikke peker på noen andre
-                select b.behandling_id, b.basert_på_behandling_id, 0 as dybde
+            with recursive 
+            personens_behandlinger as (
+                select b.behandling_id, b.basert_på_behandling_id
                 from behandling b
                 inner join person_behandling pb on pb.behandling_id = b.behandling_id 
-                where pb.ident = ANY(:identer) and b.basert_på_behandling_id is null
+                where pb.ident = ANY(:identer)
+            ), 
+            behandlingkjede as (
+                -- rotbehandlinger, de som ikke peker på noen andre
+                select b.behandling_id, b.basert_på_behandling_id, 0 as dybde
+                from personens_behandlinger b
+                where b.basert_på_behandling_id is null
                 
                 union all
                 -- rekursive behandlinger. avstanden øker jo lenger fremover i kjeden vi går
                 select r.behandling_id, r.basert_på_behandling_id, bk.dybde + 1
-                from behandling r
+                from personens_behandlinger r
                 join behandlingkjede bk on bk.behandling_id = r.basert_på_behandling_id
             )
             """.trimIndent()

--- a/mediator/src/main/resources/db/migration/V90__FJERN_INDEKS_BASERT_PAA.sql
+++ b/mediator/src/main/resources/db/migration/V90__FJERN_INDEKS_BASERT_PAA.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_behandling_basert_pa;

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/PostgresMigrationTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/PostgresMigrationTest.kt
@@ -10,7 +10,7 @@ class PostgresMigrationTest {
     fun `Migration scripts are applied successfully`() {
         withCleanDb {
             val migrations = runMigration()
-            migrations shouldBeExactly 22
+            migrations shouldBeExactly 23
         }
     }
 }


### PR DESCRIPTION
indeksen ble ikke tatt i bruk av query planneren, til tross for mange forskjellige forsøk/debugging med claude.

den enkleste løsningen var å redusere problemet ved å finne personens behandlinger først. Da gjøres utvalget så lite at det ikke trengs indekser på behandling.