### PR TITLE
Reduser mengden kopiering av alle opplysninger når vi vil filtrere per dag

### DIFF
--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/TaptArbeidstidStans.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/TaptArbeidstidStans.kt
@@ -30,7 +30,7 @@ class TaptArbeidstidStans : ProsessPlugin {
             val stansperiode = Gyldighetsperiode(stansFraOgMed)
 
             // Unngå å legge til opplysningen en gang til.
-            val harLøpendeRett = opplysninger.forDato(stansFraOgMed).finnOpplysning(KravPåDagpenger.harLøpendeRett)
+            val harLøpendeRett = opplysninger.finnOpplysning(KravPåDagpenger.harLøpendeRett, stansFraOgMed)
             if (!harLøpendeRett.verdi || harLøpendeRett.kilde is Saksbehandlerkilde) {
                 return
             }

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/beregning/BeregningsperiodeFabrikk.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/beregning/BeregningsperiodeFabrikk.kt
@@ -60,7 +60,7 @@ class BeregningsperiodeFabrikk(
 
     private fun hentMeldekortDagerMedRett(): List<LocalDate> {
         val perioderMedRett = opplysninger.finnAlle(harLøpendeRett).filter { it.verdi }.map { it.gyldighetsperiode }
-        val meldtITide = opplysninger.forDato(meldeperiode.fraOgMed).finnOpplysning(meldtITide).verdi
+        val meldtITide = opplysninger.finnOpplysning(meldtITide, meldeperiode.fraOgMed).verdi
         val dagerMedRett =
             meldeperiode
                 .filter { meldekortDag -> perioderMedRett.any { it.inneholder(meldekortDag) } }
@@ -68,7 +68,7 @@ class BeregningsperiodeFabrikk(
         return if (meldtITide) {
             dagerMedRett
         } else {
-            dagerMedRett.filter { meldekortDag -> opplysninger.forDato(meldekortDag).erSann(Beregning.meldt) }
+            dagerMedRett.filter { meldekortDag -> opplysninger.erSann(Beregning.meldt, meldekortDag) }
         }
     }
 

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/SøknadInnsendtHendelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/SøknadInnsendtHendelse.kt
@@ -64,6 +64,9 @@ class SøknadInnsendtHendelse(
             }
 
         if (basertPå == null && fagsakId == 0) {
+            // Vi tar kun inn søknad så lenge den har en fagsakId i seg. Det vil være søknader om nytt rett (som oppretter sak i Arena).
+            // Søknad om gjenopptak vil ikke ha fagsakId.
+            // Har vi en behandlingskjede (noe er innvilget) så vil vi også fange opp gjenopptaksøknader.
             return null
         }
 

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/LesbarOpplysninger.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/LesbarOpplysninger.kt
@@ -6,13 +6,23 @@ import java.util.UUID
 interface LesbarOpplysninger {
     val id: UUID
 
-    val kunEgne: Opplysninger
+    val kunEgne: LesbarOpplysninger
 
     fun <T : Any> finnOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>
+
+    fun <T : Any> finnOpplysning(
+        opplysningstype: Opplysningstype<T>,
+        gjelderFor: LocalDate,
+    ): Opplysning<T> = forDato(gjelderFor).finnOpplysning(opplysningstype)
 
     fun <T : Any> finnNullableOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>?
 
     fun <T : Any> har(opplysningstype: Opplysningstype<T>): Boolean
+
+    fun <T : Any> har(
+        opplysningstype: Opplysningstype<T>,
+        gjelderFor: LocalDate,
+    ): Boolean = forDato(gjelderFor).har(opplysningstype)
 
     fun <T : Any> mangler(opplysningstype: Opplysningstype<T>): Boolean = !har(opplysningstype)
 
@@ -27,6 +37,11 @@ interface LesbarOpplysninger {
     fun forDato(gjelderFor: LocalDate): LesbarOpplysninger
 
     fun erSann(opplysningstype: Opplysningstype<Boolean>) = har(opplysningstype) && finnOpplysning(opplysningstype).verdi
+
+    fun erSann(
+        opplysningstype: Opplysningstype<Boolean>,
+        gjelderFor: LocalDate,
+    ) = har(opplysningstype, gjelderFor) && finnOpplysning(opplysningstype, gjelderFor).verdi
 
     fun oppfyller(opplysningstype: Opplysningstype<Boolean>) = erSann(opplysningstype)
 

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/LesbarOpplysningerMedLogg.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/LesbarOpplysningerMedLogg.kt
@@ -22,6 +22,13 @@ class LesbarOpplysningerMedLogg(
             oppslag.add(this)
         }
 
+    override fun <T : Any> finnOpplysning(
+        opplysningstype: Opplysningstype<T>,
+        gjelderFor: LocalDate,
+    ) = opplysninger.finnOpplysning(opplysningstype, gjelderFor).apply {
+        oppslag.add(this)
+    }
+
     override fun <T : Any> finnNullableOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>? =
         opplysninger.finnNullableOpplysning(opplysningstype)?.apply {
             oppslag.add(this)
@@ -39,12 +46,30 @@ class LesbarOpplysningerMedLogg(
             }
         }
 
+    override fun <T : Any> har(
+        opplysningstype: Opplysningstype<T>,
+        gjelderFor: LocalDate,
+    ) = opplysninger.har(opplysningstype, gjelderFor).also { harOpplysning ->
+        if (harOpplysning) {
+            oppslag.add(opplysninger.finnOpplysning(opplysningstype, gjelderFor))
+        }
+    }
+
     override fun erSann(opplysningstype: Opplysningstype<Boolean>) =
         opplysninger.erSann(opplysningstype).also {
             if (opplysninger.har(opplysningstype)) {
                 oppslag.add(opplysninger.finnOpplysning(opplysningstype))
             }
         }
+
+    override fun erSann(
+        opplysningstype: Opplysningstype<Boolean>,
+        gjelderFor: LocalDate,
+    ) = opplysninger.erSann(opplysningstype, gjelderFor).also {
+        if (opplysninger.har(opplysningstype, gjelderFor)) {
+            oppslag.add(opplysninger.finnOpplysning(opplysningstype, gjelderFor))
+        }
+    }
 
     override fun finnFlere(opplysningstyper: List<Opplysningstype<*>>) = TODO("Not yet implemented")
 
@@ -54,7 +79,7 @@ class LesbarOpplysningerMedLogg(
 
     override fun erErstattet(opplysninger: List<Opplysning<*>>) = TODO("Not yet implemented")
 
-    override val kunEgne: Opplysninger get() = TODO("Not yet implemented")
+    override val kunEgne: LesbarOpplysninger get() = TODO("Not yet implemented")
 
     override fun somListe(filter: LesbarOpplysninger.Filter) = TODO("Not yet implemented")
 

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysninger.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysninger.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.opplysning
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.dagpenger.opplysning.LesbarOpplysninger.Filter
-import no.nav.dagpenger.opplysning.Opplysning.Companion.gyldigeFor
 import no.nav.dagpenger.uuid.UUIDv7
 import java.time.LocalDate
 import java.util.UUID
@@ -27,7 +26,7 @@ class Opplysninger private constructor(
 
     private var alleOpplysningerMap = alleOpplysninger.groupBy { it.opplysningstype }
 
-    override val kunEgne get() = Opplysninger(id = id, opplysninger = egne)
+    override val kunEgne: LesbarOpplysninger get() = OpplysningerView(this, bareEgne = true)
 
     private fun refreshOpplysninger() {
         alleOpplysninger.refresh()
@@ -92,6 +91,13 @@ class Opplysninger private constructor(
     override fun <T : Any> finnOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T> =
         finnNullableOpplysning(opplysningstype) ?: throw IllegalStateException("Har ikke opplysning $opplysningstype som er gyldig")
 
+    override fun <T : Any> finnOpplysning(
+        opplysningstype: Opplysningstype<T>,
+        gjelderFor: LocalDate,
+    ): Opplysning<T> =
+        finnNullableOpplysningMedFiltre(opplysningstype, gjelderFor, false)
+            ?: throw IllegalStateException("Har ikke opplysning $opplysningstype som er gyldig for $gjelderFor")
+
     override fun <T : Any> finnNullableOpplysning(opplysningstype: Opplysningstype<T>) =
         finnNullableOpplysning(opplysningstype, Gyldighetsperiode())
 
@@ -101,6 +107,11 @@ class Opplysninger private constructor(
 
     override fun <T : Any> har(opplysningstype: Opplysningstype<T>) = alleOpplysninger.any { it.er(opplysningstype) }
 
+    override fun <T : Any> har(
+        opplysningstype: Opplysningstype<T>,
+        gjelderFor: LocalDate,
+    ) = finnNullableOpplysningMedFiltre(opplysningstype, gjelderFor, false) != null
+
     override fun finnFlere(opplysningstyper: List<Opplysningstype<*>>) =
         opplysningstyper.mapNotNull { type -> alleOpplysninger.lastOrNull { it.er(type) } }
 
@@ -109,11 +120,7 @@ class Opplysninger private constructor(
     override fun <T : Any> finnAlle(opplysningstype: Opplysningstype<T>) =
         alleOpplysninger.filter { it.er(opplysningstype) }.filterIsInstance<Opplysning<T>>()
 
-    override fun forDato(gjelderFor: LocalDate): LesbarOpplysninger {
-        val forDato = alleOpplysninger.gyldigeFor(gjelderFor)
-        val (aktiveForDato, basertPåDato) = forDato.partition { it in egne }
-        return Opplysninger(id, aktiveForDato, Opplysninger(UUIDv7.ny(), basertPåDato))
-    }
+    override fun forDato(gjelderFor: LocalDate): LesbarOpplysninger = OpplysningerView(this, gjelderFor = gjelderFor)
 
     override fun somListe(filter: Filter) =
         when (filter) {
@@ -131,7 +138,11 @@ class Opplysninger private constructor(
             refreshOpplysninger()
         }
 
-    fun fjern(opplysningId: UUID) = fjern(kunEgne.finnOpplysning(opplysningId))
+    fun fjern(opplysningId: UUID) =
+        fjern(
+            egne.lastOrNull { it.id == opplysningId }
+                ?: throw OpplysningIkkeFunnetException("Har ikke egen opplysning med id=$opplysningId"),
+        )
 
     private fun fjern(
         opplysning: Opplysning<*>,
@@ -230,6 +241,32 @@ class Opplysninger private constructor(
                 )
         return medGyldighetsperiode(forkortetPeriode).apply {
             erUtdatert = utfordrer.erUtdatert
+        }
+    }
+
+    // Interne hjelpemetoder for OpplysningerView
+    internal fun hentOpplysninger(bareEgne: Boolean): List<Opplysning<*>> =
+        if (bareEgne) egne.utenErstattet() else alleOpplysninger.toList()
+
+    internal fun <T : Any> finnNullableOpplysningMedFiltre(
+        opplysningstype: Opplysningstype<T>,
+        gjelderFor: LocalDate?,
+        bareEgne: Boolean,
+    ): Opplysning<T>? {
+        val kandidater =
+            if (bareEgne) {
+                egne
+                    .filter { it.er(opplysningstype) }
+                    .filterIsInstance<Opplysning<T>>()
+            } else {
+                alleOpplysningerMap[opplysningstype]
+                    ?.filterIsInstance<Opplysning<T>>()
+                    ?: emptyList()
+            }
+        return if (gjelderFor != null) {
+            kandidater.lastOrNull { it.gyldighetsperiode.inneholder(gjelderFor) }
+        } else {
+            kandidater.lastOrNull()
         }
     }
 

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/OpplysningerView.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/OpplysningerView.kt
@@ -1,0 +1,85 @@
+package no.nav.dagpenger.opplysning
+
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Et lett, kopieringsfritt view over [Opplysninger] som filtrerer på dato og/eller eierskap.
+ *
+ * I stedet for å lage en ny [Opplysninger]-instans (med kopiering av lister), holder viewet
+ * bare en referanse til den opprinnelige instansen og anvender filtre ved oppslag.
+ *
+ * Views er komponebare: `forDato(dato)` på et view med `bareEgne=true` gir et nytt view
+ * med begge filtre aktive.
+ */
+internal class OpplysningerView(
+    private val source: Opplysninger,
+    private val gjelderFor: LocalDate? = null,
+    private val bareEgne: Boolean = false,
+) : LesbarOpplysninger {
+    override val id: UUID get() = source.id
+
+    override val kunEgne: LesbarOpplysninger
+        get() = OpplysningerView(source, gjelderFor, bareEgne = true)
+
+    override fun <T : Any> finnOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T> =
+        finnNullableOpplysning(opplysningstype)
+            ?: throw IllegalStateException("Har ikke opplysning $opplysningstype som er gyldig")
+
+    override fun <T : Any> finnNullableOpplysning(opplysningstype: Opplysningstype<T>): Opplysning<T>? =
+        source.finnNullableOpplysningMedFiltre(opplysningstype, gjelderFor, bareEgne)
+
+    override fun finnOpplysning(opplysningId: UUID): Opplysning<*> {
+        val opplysning =
+            hentBaseListe().lastOrNull { it.id == opplysningId }
+                ?: throw OpplysningIkkeFunnetException("Har ikke opplysning med id=$opplysningId")
+        return opplysning
+    }
+
+    override fun <T : Any> har(opplysningstype: Opplysningstype<T>): Boolean = finnNullableOpplysning(opplysningstype) != null
+
+    override fun finnFlere(opplysningstyper: List<Opplysningstype<*>>): List<Opplysning<*>> =
+        opplysningstyper.mapNotNull { type ->
+            hentBaseListe().lastOrNull { it.er(type) }
+        }
+
+    override fun <T : Any> finnAlle(opplysningstyper: List<Opplysningstype<T>>): List<Opplysning<T>> =
+        opplysningstyper.flatMap { type -> finnAlle(type) }
+
+    override fun <T : Any> finnAlle(opplysningstype: Opplysningstype<T>): List<Opplysning<T>> =
+        hentBaseListe()
+            .filter { it.er(opplysningstype) }
+            .filterIsInstance<Opplysning<T>>()
+
+    override fun forDato(gjelderFor: LocalDate): LesbarOpplysninger = OpplysningerView(source, gjelderFor, bareEgne)
+
+    override fun erSann(opplysningstype: Opplysningstype<Boolean>): Boolean = har(opplysningstype) && finnOpplysning(opplysningstype).verdi
+
+    override fun erErstattet(opplysninger: List<Opplysning<*>>): Boolean {
+        // Viktig: Bruk bare opplysninger som er gyldige for dette viewet, slik at
+        // erstatninger utenfor viewets datofilter ikke påvirker resultatet.
+        val filtrert = hentBaseListe()
+        val erstattetIder = filtrert.mapNotNull { it.erstatter }.map { it.id }.toSet()
+        return opplysninger.any { it.id in erstattetIder }
+    }
+
+    override fun somListe(filter: LesbarOpplysninger.Filter): List<Opplysning<*>> {
+        val effektivFilter =
+            if (bareEgne) LesbarOpplysninger.Filter.Egne else filter
+        val baseListe = source.somListe(effektivFilter)
+        return if (gjelderFor != null) {
+            baseListe.filter { it.gyldighetsperiode.inneholder(gjelderFor) }
+        } else {
+            baseListe
+        }
+    }
+
+    private fun hentBaseListe(): List<Opplysning<*>> {
+        val base = source.hentOpplysninger(bareEgne)
+        return if (gjelderFor != null) {
+            base.filter { it.gyldighetsperiode.inneholder(gjelderFor) }
+        } else {
+            base
+        }
+    }
+}

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningerTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningerTest.kt
@@ -71,6 +71,11 @@ class OpplysningerTest {
 
         opplysninger2.somListe().map { it.verdi } shouldContainInOrder listOf(0.5, 1.0, 2.0, 5.0)
 
+        // To ulike måter å hente ut opplysninger på en bestemt dag
+        opplysninger2.finnOpplysning(desimaltall, 1.januar).verdi shouldBe 0.5
+        opplysninger2.finnOpplysning(desimaltall, 9.januar).verdi shouldBe 2.0
+        opplysninger2.finnOpplysning(desimaltall, 12.januar).verdi shouldBe 5.0
+
         opplysninger2.forDato(1.januar).finnOpplysning(desimaltall).verdi shouldBe 0.5
         opplysninger2.forDato(9.januar).finnOpplysning(desimaltall).verdi shouldBe 2.0
         opplysninger2.forDato(12.januar).finnOpplysning(desimaltall).verdi shouldBe 5.0

--- a/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningerViewTest.kt
+++ b/opplysninger/src/test/kotlin/no/nav/dagpenger/opplysning/OpplysningerViewTest.kt
@@ -1,0 +1,99 @@
+package no.nav.dagpenger.opplysning
+
+import io.kotest.matchers.shouldBe
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.boolskA
+import no.nav.dagpenger.opplysning.TestOpplysningstyper.desimaltall
+import org.junit.jupiter.api.Test
+
+class OpplysningerViewTest {
+    @Test
+    fun `view er live - ser nye opplysninger lagt til etter at viewet ble opprettet`() {
+        val opplysninger = Opplysninger()
+        opplysninger.leggTil(Faktum(desimaltall, 1.0, Gyldighetsperiode(1.januar)))
+
+        val view = opplysninger.forDato(5.januar)
+        view.finnOpplysning(desimaltall).verdi shouldBe 1.0
+
+        // Legg til ny opplysning som erstatter den forrige fra 3. januar
+        opplysninger.leggTil(Faktum(desimaltall, 2.0, Gyldighetsperiode(3.januar)))
+
+        // Viewet skal se den nye verdien (live, ikke snapshot)
+        view.finnOpplysning(desimaltall).verdi shouldBe 2.0
+    }
+
+    @Test
+    fun `view-kjeding - kunEgne og forDato kombinerer filtre`() {
+        val parent = Opplysninger()
+        parent.leggTil(Faktum(boolskA, true, Gyldighetsperiode(1.januar)))
+
+        val child = Opplysninger.basertPå(parent)
+        child.leggTil(Faktum(boolskA, false, Gyldighetsperiode(10.januar)))
+
+        // kunEgne.forDato skal bare se egne opplysninger filtrert på dato
+        val view = child.kunEgne.forDato(15.januar)
+        view.har(boolskA) shouldBe true
+        view.finnOpplysning(boolskA).verdi shouldBe false
+
+        // forDato.kunEgne skal gi samme resultat
+        val view2 = child.forDato(15.januar).kunEgne
+        view2.har(boolskA) shouldBe true
+        view2.finnOpplysning(boolskA).verdi shouldBe false
+    }
+
+    @Test
+    fun `kunEgne-view ser ikke arvede opplysninger`() {
+        val parent = Opplysninger()
+        parent.leggTil(Faktum(desimaltall, 1.0))
+
+        val child = Opplysninger.basertPå(parent)
+
+        child.har(desimaltall) shouldBe true
+        child.kunEgne.har(desimaltall) shouldBe false
+    }
+
+    @Test
+    fun `dato-overload på Opplysninger gir samme resultat som forDato-view`() {
+        val opplysninger = Opplysninger()
+        opplysninger.leggTil(Faktum(desimaltall, 1.0, Gyldighetsperiode(1.januar, 10.januar)))
+        opplysninger.leggTil(Faktum(desimaltall, 2.0, Gyldighetsperiode(11.januar)))
+
+        opplysninger.finnOpplysning(desimaltall, 5.januar).verdi shouldBe 1.0
+        opplysninger.forDato(5.januar).finnOpplysning(desimaltall).verdi shouldBe 1.0
+
+        opplysninger.finnOpplysning(desimaltall, 15.januar).verdi shouldBe 2.0
+        opplysninger.forDato(15.januar).finnOpplysning(desimaltall).verdi shouldBe 2.0
+
+        opplysninger.har(desimaltall, 5.januar) shouldBe true
+        opplysninger.har(desimaltall, 15.januar) shouldBe true
+    }
+
+    @Test
+    fun `erSann med dato-overload`() {
+        val opplysninger = Opplysninger()
+        opplysninger.leggTil(Faktum(boolskA, true, Gyldighetsperiode(1.januar, 10.januar)))
+        opplysninger.leggTil(Faktum(boolskA, false, Gyldighetsperiode(11.januar)))
+
+        opplysninger.erSann(boolskA, 5.januar) shouldBe true
+        opplysninger.erSann(boolskA, 15.januar) shouldBe false
+    }
+
+    @Test
+    fun `somListe på view filtrerer korrekt`() {
+        val parent = Opplysninger()
+        parent.leggTil(Faktum(desimaltall, 1.0, Gyldighetsperiode(1.januar, 10.januar)))
+        parent.leggTil(Faktum(desimaltall, 2.0, Gyldighetsperiode(11.januar)))
+
+        val child = Opplysninger.basertPå(parent)
+        child.leggTil(Faktum(boolskA, true, Gyldighetsperiode(5.januar)))
+
+        // kunEgne skal bare returnere egne opplysninger
+        child.kunEgne.somListe().size shouldBe 1
+        child.kunEgne
+            .somListe()
+            .first()
+            .verdi shouldBe true
+
+        // forDato skal filtrere på dato
+        child.forDato(5.januar).somListe().size shouldBe 2
+    }
+}


### PR DESCRIPTION
Vi har mye kopiering av opplysninger når vi ønsker å hente ut opplysninger for en bestemt dag. Ofte kopierer vi flere hundre instanser, og skal bare finne en.

Denne tilnærmingen utsetter kopieringen til så sent som mulig.