### PR TITLE
 refactor(hendelse): innfør StartHendelseResultat for å gi årsak ved …

### DIFF
--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/AvsluttetArbeidssøkerperiodeHendelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/AvsluttetArbeidssøkerperiodeHendelse.kt
@@ -6,6 +6,8 @@ import no.nav.dagpenger.behandling.modell.Behandling
 import no.nav.dagpenger.behandling.modell.Rettighetstatus
 import no.nav.dagpenger.behandling.modell.hendelser.ArbeidssøkerperiodeId
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat.Opprettet
 import no.nav.dagpenger.opplysning.Avklaringkode
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
@@ -47,89 +49,91 @@ class AvsluttetArbeidssøkerperiodeHendelse(
     override fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling {
+    ): StartHendelseResultat {
         requireNotNull(forrigeBehandling) { "Må ha en behandling å ta utgangspunkt i" }
 
         val kilde = Systemkilde(meldingsreferanseId, opprettet)
 
-        return Behandling(
-            basertPå = forrigeBehandling,
-            behandler = this,
-            opplysninger =
-                listOf(
-                    Faktum(
-                        hendelseTypeOpplysningstype,
-                        type,
-                        Gyldighetsperiode.kun(skjedde),
-                        kilde = kilde,
+        return Opprettet(
+            Behandling(
+                basertPå = forrigeBehandling,
+                behandler = this,
+                opplysninger =
+                    listOf(
+                        Faktum(
+                            hendelseTypeOpplysningstype,
+                            type,
+                            Gyldighetsperiode.kun(skjedde),
+                            kilde = kilde,
+                        ),
                     ),
-                ),
-            avklaringer =
-                buildList {
-                    if (avsluttetArbeidssøkerperiode.manueltAvregistrert) {
+                avklaringer =
+                    buildList {
+                        if (avsluttetArbeidssøkerperiode.manueltAvregistrert) {
+                            add(
+                                Avklaring(
+                                    Avklaringkode(
+                                        kode = "ManueltUtmeldt",
+                                        tittel = "Bruker har blitt utmeldt av ASR utenfor dagpenger",
+                                        beskrivelse =
+                                            """Bruker har blitt utmeldt av ASR utenfor dagpenger, og må derfor vurderes manuelt. Sjekk 
+                                        |hvordan dette påvirker retten til dagpenger og fra hvilken dato en eventuell stans skal gjelde fra.
+                                            """.trimMargin(),
+                                        kanAvbrytes = false,
+                                    ),
+                                ),
+                            )
+                        }
+
+                        // TODO: Ta bort denne når vi mener disse kan gå automatisk. Husk testene i ArbeidssøkerTest
                         add(
                             Avklaring(
                                 Avklaringkode(
-                                    kode = "ManueltUtmeldt",
-                                    tittel = "Bruker har blitt utmeldt av ASR utenfor dagpenger",
-                                    beskrivelse =
-                                        """Bruker har blitt utmeldt av ASR utenfor dagpenger, og må derfor vurderes manuelt. Sjekk 
-                                        |hvordan dette påvirker retten til dagpenger og fra hvilken dato en eventuell stans skal gjelde fra.
-                                        """.trimMargin(),
+                                    kode = "UtmeldtArbeidssøker",
+                                    tittel = "Bruker har blitt utmeldt av arbeidssøkerregisteret",
+                                    beskrivelse = "Bruker er ikke lenger arbeidssøker. Ta stilling til om forslaget til stans er riktig.",
                                     kanAvbrytes = false,
                                 ),
                             ),
                         )
-                    }
+                    },
+            ).apply {
+                // Marker bruker som ikke lenger registrert fra og med avsluttetTidspunkt.
+                opplysninger.leggTil(
+                    Faktum(
+                        registrertArbeidssøker,
+                        false,
+                        Gyldighetsperiode(fraOgMed = avsluttetArbeidssøkerperiode.avsluttetTidspunkt.toLocalDate()),
+                        kilde = kilde,
+                    ),
+                )
 
-                    // TODO: Ta bort denne når vi mener disse kan gå automatisk. Husk testene i ArbeidssøkerTest
-                    add(
-                        Avklaring(
-                            Avklaringkode(
-                                kode = "UtmeldtArbeidssøker",
-                                tittel = "Bruker har blitt utmeldt av arbeidssøkerregisteret",
-                                beskrivelse = "Bruker er ikke lenger arbeidssøker. Ta stilling til om forslaget til stans er riktig.",
-                                kanAvbrytes = false,
-                            ),
+                // Om bruker sier "nei" til å stå registrert på meldekort
+                if (avsluttetArbeidssøkerperiode.sagtNei) {
+                    val meldingsdag = avsluttetArbeidssøkerperiode.fastsattMeldingsdag
+                    opplysninger.leggTil(
+                        Faktum(
+                            harLøpendeRett,
+                            false,
+                            Gyldighetsperiode(fraOgMed = meldingsdag),
+                            kilde = kilde,
                         ),
                     )
-                },
-        ).apply {
-            // Marker bruker som ikke lenger registrert fra og med avsluttetTidspunkt.
-            opplysninger.leggTil(
-                Faktum(
-                    registrertArbeidssøker,
-                    false,
-                    Gyldighetsperiode(fraOgMed = avsluttetArbeidssøkerperiode.avsluttetTidspunkt.toLocalDate()),
-                    kilde = kilde,
-                ),
-            )
-
-            // Om bruker sier "nei" til å stå registrert på meldekort
-            if (avsluttetArbeidssøkerperiode.sagtNei) {
-                val meldingsdag = avsluttetArbeidssøkerperiode.fastsattMeldingsdag
-                opplysninger.leggTil(
-                    Faktum(
-                        harLøpendeRett,
-                        false,
-                        Gyldighetsperiode(fraOgMed = meldingsdag),
-                        kilde = kilde,
-                    ),
-                )
-            }
-            // Om meldekort sendes inn etter 21-dagers fristen skal også få stans på § 4-8
-            if (avsluttetArbeidssøkerperiode.fristBrutt) {
-                val meldingsdag = avsluttetArbeidssøkerperiode.fastsattMeldingsdag
-                opplysninger.leggTil(
-                    Faktum(
-                        oppfyllerMeldeplikt,
-                        false,
-                        Gyldighetsperiode(fraOgMed = meldingsdag),
-                        kilde = kilde,
-                    ),
-                )
-            }
-        }
+                }
+                // Om meldekort sendes inn etter 21-dagers fristen skal også få stans på § 4-8
+                if (avsluttetArbeidssøkerperiode.fristBrutt) {
+                    val meldingsdag = avsluttetArbeidssøkerperiode.fastsattMeldingsdag
+                    opplysninger.leggTil(
+                        Faktum(
+                            oppfyllerMeldeplikt,
+                            false,
+                            Gyldighetsperiode(fraOgMed = meldingsdag),
+                            kilde = kilde,
+                        ),
+                    )
+                }
+            },
+        )
     }
 
     companion object {

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/BeregnFerietilleggHendelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/BeregnFerietilleggHendelse.kt
@@ -5,6 +5,8 @@ import no.nav.dagpenger.behandling.modell.Behandling
 import no.nav.dagpenger.behandling.modell.Rettighetstatus
 import no.nav.dagpenger.behandling.modell.hendelser.FerietilleggId
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat.Opprettet
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
 import no.nav.dagpenger.opplysning.Systemkilde
@@ -34,30 +36,32 @@ class BeregnFerietilleggHendelse(
     override fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling {
+    ): StartHendelseResultat {
         val kilde = Systemkilde(meldingsreferanseId, opprettet)
-        return Behandling(
-            basertPå = null,
-            behandler = this,
-            opplysninger =
-                listOf(
-                    Faktum(
-                        hendelseTypeOpplysningstype,
-                        type,
-                        Gyldighetsperiode.kun(skjedde),
-                        kilde = kilde,
-                    ),
-                    Faktum(
-                        KravPåFerietillegg.åretDetSkalBeregnesFerietilleggFor,
-                        opptjeningsår,
-                        Gyldighetsperiode(
-                            fraOgMed = LocalDate.of(opptjeningsår, 1, 1),
+        return Opprettet(
+            Behandling(
+                basertPå = null,
+                behandler = this,
+                opplysninger =
+                    listOf(
+                        Faktum(
+                            hendelseTypeOpplysningstype,
+                            type,
+                            Gyldighetsperiode.kun(skjedde),
+                            kilde = kilde,
                         ),
-                        kilde = kilde,
+                        Faktum(
+                            KravPåFerietillegg.åretDetSkalBeregnesFerietilleggFor,
+                            opptjeningsår,
+                            Gyldighetsperiode(
+                                fraOgMed = LocalDate.of(opptjeningsår, 1, 1),
+                            ),
+                            kilde = kilde,
+                        ),
                     ),
-                ),
-            // husk å legge inn avklaring som stopper disse opp så saksbehandler kan sjekke de
-            avklaringer = emptyList(),
+                // husk å legge inn avklaring som stopper disse opp så saksbehandler kan sjekke de
+                avklaringer = emptyList(),
+            ),
         )
     }
 

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/BeregnMeldekortHendelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/BeregnMeldekortHendelse.kt
@@ -7,6 +7,8 @@ import no.nav.dagpenger.behandling.modell.Rettighetstatus
 import no.nav.dagpenger.behandling.modell.hendelser.AktivitetType
 import no.nav.dagpenger.behandling.modell.hendelser.Meldekort
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat.Opprettet
 import no.nav.dagpenger.opplysning.Avklaringkode
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
@@ -39,101 +41,108 @@ class BeregnMeldekortHendelse(
     override fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling {
+    ): StartHendelseResultat {
         requireNotNull(forrigeBehandling) { "Må ha en behandling å ta utgangspunkt i" }
         val kilde = Systemkilde(meldekort.meldingsreferanseId, opprettet)
         logger.info { "Baserer meldekortberegning på: ${forrigeBehandling.behandlingId}" }
 
-        return Behandling(
-            basertPå = forrigeBehandling,
-            behandler = this,
-            opplysninger =
-                listOf(
-                    Faktum(
-                        hendelseTypeOpplysningstype,
-                        type,
-                        Gyldighetsperiode.kun(skjedde),
-                        kilde = Systemkilde(meldingsreferanseId, opprettet),
+        val behandling =
+            Behandling(
+                basertPå = forrigeBehandling,
+                behandler = this,
+                opplysninger =
+                    listOf(
+                        Faktum(
+                            hendelseTypeOpplysningstype,
+                            type,
+                            Gyldighetsperiode.kun(skjedde),
+                            kilde = Systemkilde(meldingsreferanseId, opprettet),
+                        ),
+                        Faktum(
+                            Beregning.meldeperiode,
+                            Periode(meldekort.fom, meldekort.tom),
+                            Gyldighetsperiode(meldekort.fom, meldekort.tom),
+                            kilde = kilde,
+                        ),
                     ),
-                    Faktum(
-                        Beregning.meldeperiode,
-                        Periode(meldekort.fom, meldekort.tom),
-                        Gyldighetsperiode(meldekort.fom, meldekort.tom),
-                        kilde = kilde,
-                    ),
-                ),
-            avklaringer =
-                buildList {
-                    if (meldekort.korrigeringAv != null) {
-                        add(
-                            Avklaring(
-                                Avklaringkode(
-                                    kode = "KorrigertMeldekortBehandling",
-                                    tittel = "Beregning av korrigert meldekort",
-                                    beskrivelse = "Behandlingen er korrigering av et tidligere meldekort og kan ikke automatisk behandles",
-                                    kanAvbrytes = false,
-                                ),
-                            ),
-                        )
-
-                        val sisteBeregnedeDato =
-                            forrigeBehandling
-                                .opplysninger
-                                .finnAlle(Beregning.oppfyllerKravTilTaptArbeidstidIPerioden)
-                                .lastOrNull()
-                        harBeregnetPeriodenEtterDenne =
-                            sisteBeregnedeDato
-                                ?.gyldighetsperiode
-                                ?.tilOgMed
-                                ?.isAfter(meldekort.tom) == true
-
-                        if (harBeregnetPeriodenEtterDenne) {
-                            logger.error {
-                                "Vi har allerede beregnet en periode etter denne meldeperioden! Dette blir en omgjøring bak i tid."
-                            }
+                avklaringer =
+                    buildList {
+                        if (meldekort.korrigeringAv != null) {
                             add(
                                 Avklaring(
                                     Avklaringkode(
-                                        kode = "KorrigeringUtbetaltPeriode",
-                                        tittel = "Beregning av meldekort som korrigerer tidligere periode",
-                                        beskrivelse = "Behandlingen er korrigering av et tidligere beregnet meldekort",
+                                        kode = "KorrigertMeldekortBehandling",
+                                        tittel = "Beregning av korrigert meldekort",
+                                        beskrivelse =
+                                            "Behandlingen er korrigering av et tidligere meldekort " +
+                                                "og kan ikke automatisk behandles",
+                                        kanAvbrytes = false,
+                                    ),
+                                ),
+                            )
+
+                            val sisteBeregnedeDato =
+                                forrigeBehandling
+                                    .opplysninger
+                                    .finnAlle(Beregning.oppfyllerKravTilTaptArbeidstidIPerioden)
+                                    .lastOrNull()
+                            harBeregnetPeriodenEtterDenne =
+                                sisteBeregnedeDato
+                                    ?.gyldighetsperiode
+                                    ?.tilOgMed
+                                    ?.isAfter(meldekort.tom) == true
+
+                            if (harBeregnetPeriodenEtterDenne) {
+                                logger.error {
+                                    "Vi har allerede beregnet en periode etter denne meldeperioden! Dette blir en omgjøring bak i tid."
+                                }
+                                add(
+                                    Avklaring(
+                                        Avklaringkode(
+                                            kode = "KorrigeringUtbetaltPeriode",
+                                            tittel = "Beregning av meldekort som korrigerer tidligere periode",
+                                            beskrivelse = "Behandlingen er korrigering av et tidligere beregnet meldekort",
+                                            kanAvbrytes = false,
+                                        ),
+                                    ),
+                                )
+                            }
+                        } else {
+                            add(
+                                Avklaring(
+                                    Avklaringkode(
+                                        kode = "MeldekortBehandling",
+                                        tittel = "Beregning av meldekort",
+                                        beskrivelse = "Behandlingen er opprettet av meldekort og kan ikke automatisk behandles",
                                         kanAvbrytes = false,
                                     ),
                                 ),
                             )
                         }
-                    } else {
-                        add(
-                            Avklaring(
-                                Avklaringkode(
-                                    kode = "MeldekortBehandling",
-                                    tittel = "Beregning av meldekort",
-                                    beskrivelse = "Behandlingen er opprettet av meldekort og kan ikke automatisk behandles",
-                                    kanAvbrytes = false,
-                                ),
-                            ),
-                        )
-                    }
 
-                    val aktiviteter = meldekort.dager.flatMap { it.aktiviteter }
-                    if (aktiviteter.any { aktivitet -> aktivitet.type == AktivitetType.Utdanning }) {
-                        add(
-                            Avklaring(
-                                Avklaringkode(
-                                    kode = "MeldekortMedUtdanning",
-                                    tittel = "Meldekort med utdanning",
-                                    beskrivelse = "Bruker har krysset av for utdanning eller tiltak på meldekortet. Må vurderes manuelt.",
-                                    kanAvbrytes = false,
-                                    kanKvitteres = true,
+                        val aktiviteter = meldekort.dager.flatMap { it.aktiviteter }
+                        if (aktiviteter.any { aktivitet -> aktivitet.type == AktivitetType.Utdanning }) {
+                            add(
+                                Avklaring(
+                                    Avklaringkode(
+                                        kode = "MeldekortMedUtdanning",
+                                        tittel = "Meldekort med utdanning",
+                                        beskrivelse =
+                                            "Bruker har krysset av for utdanning eller tiltak på meldekortet. " +
+                                                "Må vurderes manuelt.",
+                                        kanAvbrytes = false,
+                                        kanKvitteres = true,
+                                    ),
                                 ),
-                            ),
-                        )
-                    }
-                },
-        ).apply {
-            val meldekortOpplysninger = meldekort.tilOpplysninger(kilde)
-            meldekortOpplysninger.forEach { this.opplysninger.leggTil(it) }
-        }
+                            )
+                        }
+                    },
+            ).apply {
+                val meldekortOpplysninger = meldekort.tilOpplysninger(kilde)
+                meldekortOpplysninger.forEach { this.opplysninger.leggTil(it) }
+            }
+
+        return Opprettet(behandling)
     }
 
     companion object {

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/OmgjøringHendelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/OmgjøringHendelse.kt
@@ -5,6 +5,8 @@ import no.nav.dagpenger.behandling.modell.Rettighetstatus
 import no.nav.dagpenger.behandling.modell.hendelser.EksternId
 import no.nav.dagpenger.behandling.modell.hendelser.Hendelse
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat.Opprettet
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
 import no.nav.dagpenger.opplysning.Systemkilde
@@ -33,34 +35,36 @@ class OmgjøringHendelse(
     override fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling {
+    ): StartHendelseResultat {
         requireNotNull(forrigeBehandling) { "Omgjøring krever en tidligere behandling å basere seg på" }
 
         val kilde = Systemkilde(meldingsreferanseId, opprettet)
 
-        return Behandling(
-            basertPå = forrigeBehandling,
-            behandler =
-                Hendelse(
-                    meldingsreferanseId = meldingsreferanseId,
-                    type = type,
-                    ident = ident,
-                    eksternId = eksternId,
-                    skjedde = skjedde,
-                    opprettet = opprettet,
-                    forretningsprosess = forretningsprosess,
-                ),
-            opplysninger = emptyList(),
-            avklaringer = emptyList(),
-        ).also {
-            it.opplysninger.leggTil(
-                Faktum(
-                    hendelseTypeOpplysningstype,
-                    type,
-                    gyldighetsperiode = Gyldighetsperiode.kun(skjedde),
-                    kilde = kilde,
-                ),
-            )
-        }
+        return Opprettet(
+            Behandling(
+                basertPå = forrigeBehandling,
+                behandler =
+                    Hendelse(
+                        meldingsreferanseId = meldingsreferanseId,
+                        type = type,
+                        ident = ident,
+                        eksternId = eksternId,
+                        skjedde = skjedde,
+                        opprettet = opprettet,
+                        forretningsprosess = forretningsprosess,
+                    ),
+                opplysninger = emptyList(),
+                avklaringer = emptyList(),
+            ).also {
+                it.opplysninger.leggTil(
+                    Faktum(
+                        hendelseTypeOpplysningstype,
+                        type,
+                        gyldighetsperiode = Gyldighetsperiode.kun(skjedde),
+                        kilde = kilde,
+                    ),
+                )
+            },
+        )
     }
 }

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/OpprettBehandlingHendelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/OpprettBehandlingHendelse.kt
@@ -8,6 +8,9 @@ import no.nav.dagpenger.behandling.modell.hendelser.EksternId
 import no.nav.dagpenger.behandling.modell.hendelser.Hendelse
 import no.nav.dagpenger.behandling.modell.hendelser.SamordningId
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat.IkkeOpprettet
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat.Opprettet
 import no.nav.dagpenger.opplysning.Avklaringkode
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
@@ -33,42 +36,48 @@ class OpprettBehandlingHendelse(
     override fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling? {
-        if (forrigeBehandling == null && !startNyKjede) return null
-        if (eksternId is SamordningId && rettighetstatus.harIkkeInnvilgelse) return null
+    ): StartHendelseResultat {
+        if (forrigeBehandling == null && !startNyKjede) {
+            return IkkeOpprettet("Hendelse av type $type kan ikke starte en ny behandlingskjede uten en tidligere behandling")
+        }
+        if (eksternId is SamordningId && rettighetstatus.harIkkeInnvilgelse) {
+            return IkkeOpprettet("Samordningshendelse av type $type kan ikke opprette behandling uten innvilget dagpengerett")
+        }
 
-        return Behandling(
-            basertPå = forrigeBehandling,
-            behandler =
-                Hendelse(
-                    meldingsreferanseId = meldingsreferanseId,
-                    type = type,
-                    ident = ident,
-                    eksternId = eksternId,
-                    skjedde = skjedde,
-                    opprettet = opprettet,
-                    forretningsprosess = forretningsprosess,
-                ),
-            opplysninger =
-                listOf(
-                    Faktum(
-                        hendelseTypeOpplysningstype,
-                        type,
-                        gyldighetsperiode = Gyldighetsperiode.kun(skjedde),
-                        kilde = Systemkilde(meldingsreferanseId, opprettet),
+        return Opprettet(
+            Behandling(
+                basertPå = forrigeBehandling,
+                behandler =
+                    Hendelse(
+                        meldingsreferanseId = meldingsreferanseId,
+                        type = type,
+                        ident = ident,
+                        eksternId = eksternId,
+                        skjedde = skjedde,
+                        opprettet = opprettet,
+                        forretningsprosess = forretningsprosess,
                     ),
-                ),
-            avklaringer =
-                listOf(
-                    Avklaring(
-                        Avklaringkode(
-                            kode = "ManuellBehandling",
-                            tittel = "Manuell behandling",
-                            beskrivelse = begrunnelse ?: "Behandlingen er opprettet manuelt og kan ikke automatisk behandles",
-                            kanAvbrytes = false,
+                opplysninger =
+                    listOf(
+                        Faktum(
+                            hendelseTypeOpplysningstype,
+                            type,
+                            gyldighetsperiode = Gyldighetsperiode.kun(skjedde),
+                            kilde = Systemkilde(meldingsreferanseId, opprettet),
                         ),
                     ),
-                ),
+                avklaringer =
+                    listOf(
+                        Avklaring(
+                            Avklaringkode(
+                                kode = "ManuellBehandling",
+                                tittel = "Manuell behandling",
+                                beskrivelse = begrunnelse ?: "Behandlingen er opprettet manuelt og kan ikke automatisk behandles",
+                                kanAvbrytes = false,
+                            ),
+                        ),
+                    ),
+            ),
         )
     }
 }

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/SøknadInnsendtHendelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/SøknadInnsendtHendelse.kt
@@ -5,6 +5,9 @@ import no.nav.dagpenger.behandling.modell.Behandling
 import no.nav.dagpenger.behandling.modell.Rettighetstatus
 import no.nav.dagpenger.behandling.modell.hendelser.Hendelse
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat.IkkeOpprettet
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat.Opprettet
 import no.nav.dagpenger.behandling.modell.hendelser.SøknadId
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
@@ -41,7 +44,7 @@ class SøknadInnsendtHendelse(
     override fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling? {
+    ): StartHendelseResultat {
         val basertPå =
             forrigeBehandling?.let { forrigeBehandling ->
                 val erSammeType = forrigeBehandling.behandler.erSammeType(this)
@@ -67,53 +70,55 @@ class SøknadInnsendtHendelse(
             // Vi tar kun inn søknad så lenge den har en fagsakId i seg. Det vil være søknader om nytt rett (som oppretter sak i Arena).
             // Søknad om gjenopptak vil ikke ha fagsakId.
             // Har vi en behandlingskjede (noe er innvilget) så vil vi også fange opp gjenopptaksøknader.
-            return null
+            return IkkeOpprettet("Hendelse av type $type mangler fagsakId og har ingen behandling å basere seg på")
         }
 
         val kilde = Systemkilde(meldingsreferanseId, opprettet)
-        return Behandling(
-            basertPå = basertPå,
-            behandler =
-                Hendelse(
-                    meldingsreferanseId = meldingsreferanseId,
-                    type = type,
-                    ident = ident,
-                    eksternId = eksternId,
-                    skjedde = skjedde,
-                    opprettet = opprettet,
-                    forretningsprosess = forretningsprosess,
-                ),
-            opplysninger =
-                buildList {
-                    if (basertPå == null) {
-                        add(Faktum(fagsakIdOpplysningstype, fagsakId, kilde = kilde))
-                    }
-                },
-            avklaringer =
-                buildList {
-                    if (basertPå != null) {
-                        add(Avklaring(GjenopptakBehandling))
-                    } else {
-                        if (søknadstype == Søknadstype.Gjenopptak) {
-                            add(Avklaring(SøktGjenopptak))
+        return Opprettet(
+            Behandling(
+                basertPå = basertPå,
+                behandler =
+                    Hendelse(
+                        meldingsreferanseId = meldingsreferanseId,
+                        type = type,
+                        ident = ident,
+                        eksternId = eksternId,
+                        skjedde = skjedde,
+                        opprettet = opprettet,
+                        forretningsprosess = forretningsprosess,
+                    ),
+                opplysninger =
+                    buildList {
+                        if (basertPå == null) {
+                            add(Faktum(fagsakIdOpplysningstype, fagsakId, kilde = kilde))
                         }
-                    }
-                },
-        ).also {
-            it.opplysninger.leggTil(
-                Faktum(søknadIdOpplysningstype, eksternId.id.toString(), kilde = kilde, gyldighetsperiode = Gyldighetsperiode(skjedde)),
-            )
-            it.opplysninger.leggTil(
-                Faktum(hendelseTypeOpplysningstype, type, gyldighetsperiode = Gyldighetsperiode.kun(skjedde), kilde = kilde),
-            )
+                    },
+                avklaringer =
+                    buildList {
+                        if (basertPå != null) {
+                            add(Avklaring(GjenopptakBehandling))
+                        } else {
+                            if (søknadstype == Søknadstype.Gjenopptak) {
+                                add(Avklaring(SøktGjenopptak))
+                            }
+                        }
+                    },
+            ).also {
+                it.opplysninger.leggTil(
+                    Faktum(søknadIdOpplysningstype, eksternId.id.toString(), kilde = kilde, gyldighetsperiode = Gyldighetsperiode(skjedde)),
+                )
+                it.opplysninger.leggTil(
+                    Faktum(hendelseTypeOpplysningstype, type, gyldighetsperiode = Gyldighetsperiode.kun(skjedde), kilde = kilde),
+                )
 
-            if (basertPå != null) {
-                // Om bruker tidligere har hatt minst en periode med rett så begynner med gjenopptaksbehandling som utgangspunkt
-                if (basertPå.vedtakopplysninger.rettighetsperioder.any { rettighetsperiode -> rettighetsperiode.harRett }) {
-                    it.opplysninger.leggTil(Faktum(skalGjenopptakVurderes, true, Gyldighetsperiode(skjedde), kilde = kilde))
+                if (basertPå != null) {
+                    // Om bruker tidligere har hatt minst en periode med rett så begynner med gjenopptaksbehandling som utgangspunkt
+                    if (basertPå.vedtakopplysninger.rettighetsperioder.any { rettighetsperiode -> rettighetsperiode.harRett }) {
+                        it.opplysninger.leggTil(Faktum(skalGjenopptakVurderes, true, Gyldighetsperiode(skjedde), kilde = kilde))
+                    }
                 }
-            }
-        }
+            },
+        )
     }
 
     companion object {

--- a/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/Person.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/Person.kt
@@ -25,6 +25,7 @@ import no.nav.dagpenger.behandling.modell.hendelser.PåminnelseHendelse
 import no.nav.dagpenger.behandling.modell.hendelser.RekjørBehandlingHendelse
 import no.nav.dagpenger.behandling.modell.hendelser.SendTilbakeHendelse
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
 import no.nav.dagpenger.opplysning.TemporalCollection
 import java.time.LocalDate
 import java.util.UUID
@@ -103,31 +104,37 @@ class Person(
         // Oppskrift for å opprette en behandling
         hendelse.leggTilKontekst(this)
         val behandling =
-            hendelse.behandling(kjede?.nesteSomKanBaseresPå, rettighetstatus)?.also { behandling ->
-                logger.info {
-                    """
-                    Oppretter behandling med behandlingId=${behandling.behandlingId} for 
-                    hendelse ${hendelse.type} av ${hendelse.eksternId.id}
-                    basert på behandlingId=${behandling.basertPå?.behandlingId}
-                    """.trimIndent()
+            when (val resultat = hendelse.behandling(kjede?.nesteSomKanBaseresPå, rettighetstatus)) {
+                is StartHendelseResultat.IkkeOpprettet -> {
+                    val melding =
+                        "Kan ikke starte behandling av ${hendelse.type} med id ${hendelse.eksternId.id}: ${resultat.årsak}"
+                    hendelse.varsel(melding)
+                    logger.info { melding }
+                    return
                 }
-                if (kjede == null || behandling.basertPå == null) {
-                    behandlingkjeder.add(behandling.somKjede())
-                } else {
-                    val index = behandlingkjeder.indexOf(kjede)
-                    behandlingkjeder[index] = kjede leggTil behandling
-                }
-                observatører.forEach {
-                    behandling.registrer(
-                        PersonObservatørAdapter(ident.identifikator(), it),
-                    )
+
+                is StartHendelseResultat.Opprettet -> {
+                    resultat.behandling
                 }
             }
 
-        if (behandling == null) {
-            hendelse.varsel("Behandlingskjeden ønsker ikke å behandle hendelse ${hendelse.type}")
-            logger.warn { "Behandlingskjeden ønsker ikke å behandle hendelse ${hendelse.type} med id ${hendelse.eksternId.id} " }
-            return
+        logger.info {
+            """
+            Oppretter behandling med behandlingId=${behandling.behandlingId} for 
+            hendelse ${hendelse.type} av ${hendelse.eksternId.id}
+            basert på behandlingId=${behandling.basertPå?.behandlingId}
+            """.trimIndent()
+        }
+        if (kjede == null || behandling.basertPå == null) {
+            behandlingkjeder.add(behandling.somKjede())
+        } else {
+            val index = behandlingkjeder.indexOf(kjede)
+            behandlingkjeder[index] = kjede leggTil behandling
+        }
+        observatører.forEach {
+            behandling.registrer(
+                PersonObservatørAdapter(ident.identifikator(), it),
+            )
         }
 
         behandling.håndter(hendelse)

--- a/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/hendelser/Hendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/hendelser/Hendelse.kt
@@ -20,5 +20,5 @@ class Hendelse(
     override fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling = throw IllegalStateException("Skal ikke opprettet behandling her, skal allerede ha skjedd")
+    ): StartHendelseResultat = throw IllegalStateException("Skal ikke opprettet behandling her, skal allerede ha skjedd")
 }

--- a/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/hendelser/StartHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/behandling/modell/hendelser/StartHendelse.kt
@@ -8,6 +8,16 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
+sealed class StartHendelseResultat {
+    data class Opprettet(
+        val behandling: Behandling,
+    ) : StartHendelseResultat()
+
+    data class IkkeOpprettet(
+        val årsak: String,
+    ) : StartHendelseResultat()
+}
+
 // Baseklasse for alle hendelser som kan påvirke dagpengene til en person og må behandles
 abstract class StartHendelse(
     val meldingsreferanseId: UUID,
@@ -30,5 +40,5 @@ abstract class StartHendelse(
     abstract fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling?
+    ): StartHendelseResultat
 }

--- a/modell/src/test/kotlin/no/nav/dagpenger/behandling/modell/PersonTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/behandling/modell/PersonTest.kt
@@ -9,6 +9,7 @@ import no.nav.dagpenger.behandling.modell.BehandlingObservatør.BehandlingFerdig
 import no.nav.dagpenger.behandling.modell.hendelser.EksternId
 import no.nav.dagpenger.behandling.modell.hendelser.ManuellId
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
 import no.nav.dagpenger.opplysning.Forretningsprosess
 import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysninger
@@ -153,7 +154,7 @@ class PersonTest {
         override fun behandling(
             forrigeBehandling: Behandling?,
             rettighetstatus: TemporalCollection<Rettighetstatus>,
-        ): Behandling {
+        ): StartHendelseResultat {
             TODO("Not yet implemented")
         }
     }

--- a/modell/src/test/kotlin/no/nav/dagpenger/behandling/modell/TestHendelse.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/behandling/modell/TestHendelse.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.behandling.modell
 
 import no.nav.dagpenger.behandling.modell.hendelser.StartHendelse
+import no.nav.dagpenger.behandling.modell.hendelser.StartHendelseResultat
 import no.nav.dagpenger.behandling.modell.hendelser.SøknadId
 import no.nav.dagpenger.opplysning.Boolsk
 import no.nav.dagpenger.opplysning.Forretningsprosess
@@ -68,7 +69,7 @@ class TestHendelse(
     override fun behandling(
         forrigeBehandling: Behandling?,
         rettighetstatus: TemporalCollection<Rettighetstatus>,
-    ): Behandling {
+    ): StartHendelseResultat {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
…avvist behandling

 Erstatter Behandling? (nullable) som returtype fra StartHendelse.behandling()
 med en sealed class StartHendelseResultat med to tilstander:
 - Opprettet(behandling) – behandling ble opprettet
 - IkkeOpprettet(årsak) – behandling ble ikke opprettet, med forklaring

 Person.håndter(StartHendelse) logger nå årsaken fra IkkeOpprettet
 i stedet for en generisk melding, slik at det er lettere å forstå
 hvorfor en hendelse ikke resulterte i en ny behandling.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>