### PR TITLE
setter dataSource i konstruktøren til AvklaringRepositoryPostgres

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
@@ -15,6 +15,7 @@ import no.nav.dagpenger.behandling.mediator.api.behandlingApi
 import no.nav.dagpenger.behandling.mediator.api.simuleringApi
 import no.nav.dagpenger.behandling.mediator.api.statusPagesConfig
 import no.nav.dagpenger.behandling.mediator.audit.ApiAuditlogg
+import no.nav.dagpenger.behandling.mediator.db.PostgresDataSourceBuilder
 import no.nav.dagpenger.behandling.mediator.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.behandling.mediator.db.PostgresDataSourceBuilder.runMigration
 import no.nav.dagpenger.behandling.mediator.jobber.BehandleMeldekort
@@ -60,8 +61,8 @@ internal class ApplicationBuilder(
     private val regelverk: List<RegelverkRegistrering> = listOf(DagpengerRegistrering(), FerietilleggRegistrering())
 
     private val opplysningstyper: Set<Opplysningstype<*>> = regelverk.flatMap { it.opplysningstyper }.toSet()
-
-    private val avklaringRepository = AvklaringRepositoryPostgres()
+    private val dataSource = PostgresDataSourceBuilder.dataSource
+    private val avklaringRepository = AvklaringRepositoryPostgres(dataSource)
     private val opplysningRepository = OpplysningerRepositoryPostgres()
     private val prosessregister = Prosessregister()
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgres.kt
@@ -6,7 +6,6 @@ import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.avklaring.Avklaring.Endring.Avbrutt
 import no.nav.dagpenger.avklaring.Avklaring.Endring.Avklart
 import no.nav.dagpenger.avklaring.Avklaring.Endring.UnderBehandling
-import no.nav.dagpenger.behandling.mediator.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.behandling.mediator.objectMapper
 import no.nav.dagpenger.behandling.mediator.repository.AvklaringRepositoryObserver.NyAvklaringHendelse
 import no.nav.dagpenger.behandling.mediator.repository.JsonSerde.Companion.serde
@@ -18,12 +17,14 @@ import no.nav.dagpenger.opplysning.Saksbehandlerkilde
 import no.nav.dagpenger.uuid.UUIDv7
 import java.time.LocalDateTime
 import java.util.UUID
+import javax.sql.DataSource
 
 internal class AvklaringRepositoryPostgres private constructor(
+    private val dataSource: DataSource,
     private val observatører: MutableList<AvklaringRepositoryObserver> = mutableListOf(),
     private val kildeRepository: KildeRepository = KildeRepository(),
 ) : AvklaringRepository {
-    constructor(vararg observatører: AvklaringRepositoryObserver) : this(observatører.toMutableList())
+    constructor(dataSource: DataSource, vararg observatører: AvklaringRepositoryObserver) : this(dataSource, observatører.toMutableList())
 
     fun registerObserver(observer: AvklaringRepositoryObserver) {
         observatører.add(observer)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/Postgres.kt
@@ -4,6 +4,11 @@ import com.zaxxer.hikari.HikariDataSource
 import no.nav.dagpenger.behandling.mediator.db.PostgresDataSourceBuilder
 import org.flywaydb.core.internal.configuration.ConfigUtils
 import org.testcontainers.postgresql.PostgreSQLContainer
+import javax.sql.DataSource
+
+data class DBTestContext(
+    val dataSource: DataSource,
+)
 
 internal object Postgres {
     val instance by lazy {
@@ -13,10 +18,11 @@ internal object Postgres {
         }
     }
 
-    inline fun withMigratedDb(block: () -> Unit) {
+    inline fun withMigratedDb(block: DBTestContext.() -> Unit) {
         withCleanDb {
             PostgresDataSourceBuilder.runMigration()
-            block()
+            val testContext = DBTestContext(PostgresDataSourceBuilder.dataSource)
+            block(testContext)
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
@@ -9,6 +9,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.SentMessage
 import io.ktor.server.application.Application
 import io.mockk.mockk
 import no.nav.dagpenger.behandling.api.models.BehandlingsresultatDTO
+import no.nav.dagpenger.behandling.db.DBTestContext
 import no.nav.dagpenger.behandling.db.Postgres
 import no.nav.dagpenger.behandling.helpers.scenario.assertions.BehandlingsresultatAssertions
 import no.nav.dagpenger.behandling.mediator.BehovMediator
@@ -17,7 +18,6 @@ import no.nav.dagpenger.behandling.mediator.HendelseMediator
 import no.nav.dagpenger.behandling.mediator.MessageMediator
 import no.nav.dagpenger.behandling.mediator.api.behandlingApi
 import no.nav.dagpenger.behandling.mediator.audit.Auditlogg
-import no.nav.dagpenger.behandling.mediator.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.behandling.mediator.meldekort.MeldekortBehandlingskø
 import no.nav.dagpenger.behandling.mediator.melding.PostgresMeldingRepository
 import no.nav.dagpenger.behandling.mediator.mottak.MarkerMeldekortSomBehandletMottak
@@ -41,6 +41,7 @@ import java.util.UUID
 import kotlin.random.Random
 
 internal class SimulertDagpengerSystem(
+    dbTestContext: DBTestContext,
     oppsett: ScenarioOptions,
 ) {
     companion object {
@@ -54,7 +55,7 @@ internal class SimulertDagpengerSystem(
         PersonRepositoryPostgres(
             BehandlingRepositoryPostgres(
                 opplysningerRepository,
-                AvklaringRepositoryPostgres(AvklaringKafkaObservatør(rapid)),
+                AvklaringRepositoryPostgres(dbTestContext.dataSource, AvklaringKafkaObservatør(rapid)),
                 prosessregister,
             ),
         )
@@ -71,7 +72,7 @@ internal class SimulertDagpengerSystem(
 
     private val postgresMeldingRepository = PostgresMeldingRepository()
 
-    private val behovssporer = Behovssporer(dataSource)
+    private val behovssporer = Behovssporer(dbTestContext.dataSource)
     private val apiRepositoryPostgres = ApiRepositoryPostgres(postgresMeldingRepository, behovssporer)
     val auditlogg = TestAuditlogg()
 
@@ -154,7 +155,7 @@ internal class SimulertDagpengerSystem(
     ) {
         inline fun test(block: SimulertDagpengerSystem.() -> Unit) {
             Postgres.withMigratedDb {
-                val test = SimulertDagpengerSystem(this)
+                val test = SimulertDagpengerSystem(this, this@ScenarioOptions)
                 test.opprettPerson(ident)
                 test.block()
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgresTest.kt
@@ -20,15 +20,15 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class AvklaringRepositoryPostgresTest {
-    private val repository = AvklaringRepositoryPostgres()
-
     @Test
     fun `lagrer og rehydrer avklaringer`() {
         withMigratedDb {
+            val repository = AvklaringRepositoryPostgres(dataSource)
+
             val kode1 = Avklaringkode("JobbetUtenforNorge", "Arbeid utenfor Norge", "Personen har oppgitt arbeid utenfor Norge")
             val kode2 = Avklaringkode("HarVunnetNobelprisen", "Har vunnet nobelprisen", "Personen har vunnet en nobelpris ")
 
-            val behandling = TestBehandling(avklaring(kode1), avklaring(kode2))
+            val behandling = TestBehandling(repository, avklaring(kode1), avklaring(kode2))
             val avklaringer = repository.hentAvklaringer(behandling.behandlingId)
 
             avklaringer.size shouldBe 2
@@ -38,9 +38,11 @@ class AvklaringRepositoryPostgresTest {
     @Test
     fun `lagrer kilde og begrunnelse på avklarte avklaringer`() {
         withMigratedDb {
+            val repository = AvklaringRepositoryPostgres(dataSource)
+
             val kode1 = Avklaringkode("JobbetUtenforNorge", "Arbeid utenfor Norge", "Personen har oppgitt arbeid utenfor Norge")
 
-            val behandling = TestBehandling(avklaring(kode1))
+            val behandling = TestBehandling(repository, avklaring(kode1))
             behandling.avklar("123", "begrunnelse")
 
             val avklaringer = repository.hentAvklaringer(behandling.behandlingId)
@@ -57,6 +59,8 @@ class AvklaringRepositoryPostgresTest {
     @Test
     fun `tar vare på rekkefølge av endringer`() {
         withMigratedDb {
+            val repository = AvklaringRepositoryPostgres(dataSource)
+
             val kode1 = Avklaringkode("JobbetUtenforNorge", "Arbeid utenfor Norge", "Personen har oppgitt arbeid utenfor Norge")
 
             val avklaring = avklaring(kode1)
@@ -68,21 +72,22 @@ class AvklaringRepositoryPostgresTest {
             val forventedeTilstander = listOf("UnderBehandling", "Avklart", "UnderBehandling", "Avklart")
             avklaring.endringer.map { it::class.simpleName!! } shouldBe forventedeTilstander
 
-            val behandling = TestBehandling(avklaring)
+            val behandling = TestBehandling(repository, avklaring)
             val avklaringerFraDb = repository.hentAvklaringer(behandling.behandlingId)
 
-            repository.hentAvklaringer(TestBehandling(avklaring).behandlingId)
-            repository.hentAvklaringer(TestBehandling(avklaring).behandlingId)
-            repository.hentAvklaringer(TestBehandling(avklaring).behandlingId)
-            repository.hentAvklaringer(TestBehandling(avklaring).behandlingId)
-            repository.hentAvklaringer(TestBehandling(avklaring).behandlingId)
-            repository.hentAvklaringer(TestBehandling(avklaring).behandlingId)
+            repository.hentAvklaringer(TestBehandling(repository, avklaring).behandlingId)
+            repository.hentAvklaringer(TestBehandling(repository, avklaring).behandlingId)
+            repository.hentAvklaringer(TestBehandling(repository, avklaring).behandlingId)
+            repository.hentAvklaringer(TestBehandling(repository, avklaring).behandlingId)
+            repository.hentAvklaringer(TestBehandling(repository, avklaring).behandlingId)
+            repository.hentAvklaringer(TestBehandling(repository, avklaring).behandlingId)
 
             avklaringerFraDb.single().endringer.map { it::class.simpleName!! } shouldBe forventedeTilstander
         }
     }
 
-    private inner class TestBehandling(
+    private class TestBehandling(
+        repository: AvklaringRepository,
         vararg avklaring: Avklaring,
     ) {
         val behandlingId get() = behandling.behandlingId

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresPerformanceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresPerformanceTest.kt
@@ -105,7 +105,7 @@ class BehandlingRepositoryPostgresPerformanceTest {
         val antallOpplysningerPerBehandling = 100
 
         withMigratedDb {
-            val avklaringRepository = AvklaringRepositoryPostgres()
+            val avklaringRepository = AvklaringRepositoryPostgres(dataSource)
             val opplysningerRepository = OpplysningerRepositoryPostgres()
             // Registrer forretningsprosesser og opplysningstyper
             val prosessregister = Prosessregister()
@@ -203,7 +203,7 @@ class BehandlingRepositoryPostgresPerformanceTest {
         val antallOpplysningerPerBehandling = 50
 
         withMigratedDb {
-            val avklaringRepository = AvklaringRepositoryPostgres()
+            val avklaringRepository = AvklaringRepositoryPostgres(dataSource)
             val opplysningerRepository = OpplysningerRepositoryPostgres()
             // Registrer forretningsprosesser og opplysningstyper
             val prosessregister = Prosessregister()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresTest.kt
@@ -97,7 +97,7 @@ class BehandlingRepositoryPostgresTest {
             TestBehandlinger.registrerTestProsesser(prosessregister)
             opplysningerRepository.lagreOpplysningstyper(opplysningstyper)
 
-            val avklaringRepository = AvklaringRepositoryPostgres()
+            val avklaringRepository = AvklaringRepositoryPostgres(dataSource)
             val behandlingRepositoryPostgres = BehandlingRepositoryPostgres(opplysningerRepository, avklaringRepository, prosessregister)
 
             val b1 = nyBehandling(null, Ferdig, Opplysninger.med(datoOpplysning))
@@ -135,7 +135,7 @@ class BehandlingRepositoryPostgresTest {
             TestBehandlinger.registrerTestProsesser(prosessregister)
             opplysningerRepository.lagreOpplysningstyper(opplysningstyper)
 
-            val avklaringRepository = AvklaringRepositoryPostgres()
+            val avklaringRepository = AvklaringRepositoryPostgres(dataSource)
             val behandlingRepositoryPostgres = BehandlingRepositoryPostgres(opplysningerRepository, avklaringRepository, prosessregister)
 
             val b1 = nyBehandling(null, Ferdig, Opplysninger.med(datoOpplysning))
@@ -172,7 +172,7 @@ class BehandlingRepositoryPostgresTest {
             TestBehandlinger.registrerTestProsesser(prosessregister)
             opplysningerRepository.lagreOpplysningstyper(opplysningstyper)
 
-            val avklaringRepository = AvklaringRepositoryPostgres()
+            val avklaringRepository = AvklaringRepositoryPostgres(dataSource)
             val behandlingRepositoryPostgres = BehandlingRepositoryPostgres(opplysningerRepository(), avklaringRepository, prosessregister)
 
             opprettKjede(behandlingRepositoryPostgres, listOf(basertPåBehandling, behandling))


### PR DESCRIPTION
starter arbeider med å sette datasource som parameter til alle Repo-klassene, slik at datasource ikke deles globalt mellom alle tester.


**PS**: En liten endring nå er at vi henter ut `PostgresDataSourceBuilder.dataSource` i init av ApplicationBuilder. Hvis vi ønsker å utsette tidspunktet vi kobler oss til databasen så kan vi endre konstrukør-parameteret til Repo-klassene som en supplier:
```kotlin
class SomeRepo(private val dataSource: () -> DataSource) {
...
}
```
Eneste vi må huske på da er å anvende en `lazy` sånn her ish:
```kotlin
fun startApp() {
    val datasource by lazy { PostgresDataSourceBuilder.dataSource }
    val repo = SomeRepo { datasource }
    
    ... 
}
```