### PR TITLE
refactor: Ekstraher BehandlingRuntime fra ApplicationBuilder

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/AktivitetsloggMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/AktivitetsloggMediator.kt
@@ -8,11 +8,18 @@ import no.nav.dagpenger.aktivitetslogg.AktivitetsloggEventMapper
 import no.nav.dagpenger.aktivitetslogg.AktivitetsloggHendelse
 import no.nav.dagpenger.behandling.mediator.Metrikk.aktivitetsloggTimer
 
-internal class AktivitetsloggMediator {
+interface IAktivitetsloggMediator {
+    fun håndter(
+        context: MessageContext,
+        hendelse: AktivitetsloggHendelse,
+    )
+}
+
+class AktivitetsloggMediator : IAktivitetsloggMediator {
     private val aktivitetsloggEventMapper = AktivitetsloggEventMapper()
 
     @WithSpan
-    fun håndter(
+    override fun håndter(
         context: MessageContext,
         hendelse: AktivitetsloggHendelse,
     ) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
@@ -11,32 +11,14 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.tracer.initializer.SpanContextSupplier
 import no.nav.dagpenger.behandling.mediator.api.ApiMessageContext
-import no.nav.dagpenger.behandling.mediator.api.behandlingApi
 import no.nav.dagpenger.behandling.mediator.api.simuleringApi
 import no.nav.dagpenger.behandling.mediator.api.statusPagesConfig
 import no.nav.dagpenger.behandling.mediator.audit.ApiAuditlogg
 import no.nav.dagpenger.behandling.mediator.db.PostgresDataSourceBuilder
 import no.nav.dagpenger.behandling.mediator.jobber.BehandleMeldekort
 import no.nav.dagpenger.behandling.mediator.jobber.SlettFjernetOpplysninger
-import no.nav.dagpenger.behandling.mediator.meldekort.MeldekortBehandlingskø
-import no.nav.dagpenger.behandling.mediator.melding.PostgresMeldingRepository
-import no.nav.dagpenger.behandling.mediator.mottak.ArenaOppgaveMottak
-import no.nav.dagpenger.behandling.mediator.mottak.MarkerMeldekortSomBehandletMottak
-import no.nav.dagpenger.behandling.mediator.mottak.SakRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.ApiRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.AvklaringKafkaObservatør
-import no.nav.dagpenger.behandling.mediator.repository.AvklaringRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.BehandlingRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.KildeRepository
-import no.nav.dagpenger.behandling.mediator.repository.MeldekortRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.OpplysningerRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.PersonRepositoryPostgres
 import no.nav.dagpenger.behandling.mediator.repository.VaktmesterPostgresRepo
-import no.nav.dagpenger.behandling.mediator.repository.VentendeMeldekortDings
-import no.nav.dagpenger.behandling.mediator.utboks.UtboksLagerPostgres
 import no.nav.dagpenger.ferietillegg.FerietilleggRegistrering
-import no.nav.dagpenger.opplysning.Opplysningstype
-import no.nav.dagpenger.opplysning.Prosessregister
 import no.nav.dagpenger.regel.DagpengerRegistrering
 import no.nav.dagpenger.regelverk.RegelverkRegistrering
 import no.nav.helse.rapids_rivers.RapidApplication
@@ -59,54 +41,26 @@ internal class ApplicationBuilder(
 
     private val regelverk: List<RegelverkRegistrering> = listOf(DagpengerRegistrering(), FerietilleggRegistrering())
 
-    private val opplysningstyper: Set<Opplysningstype<*>> = regelverk.flatMap { it.opplysningstyper }.toSet()
     private val postgresDataSourceBuilder = PostgresDataSourceBuilder()
     private val dataSource = postgresDataSourceBuilder.dataSource
-    private val kildeRepository = KildeRepository(dataSource)
-    private val avklaringRepository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
-    private val opplysningRepository = OpplysningerRepositoryPostgres(dataSource, kildeRepository)
-    private val prosessregister = Prosessregister()
 
-    private val personRepository =
-        PersonRepositoryPostgres(
-            dataSource,
-            BehandlingRepositoryPostgres(
-                dataSource,
-                opplysningRepository,
-                avklaringRepository,
-                kildeRepository,
-                prosessregister,
-            ),
-        )
-
-    private val meldekortRepositoryPostgres = MeldekortRepositoryPostgres(dataSource)
-    private val ventendeMeldekort = VentendeMeldekortDings(meldekortRepositoryPostgres)
-
-    private val behandlingMetrikker = BehandlingMetrikker()
-
-    private val behovssporer = Behovssporer(dataSource)
-
-    private val hendelseMediator =
-        HendelseMediator(
-            UtboksLagerPostgres(dataSource),
-            personRepository,
-            meldekortRepositoryPostgres,
-            behovMediator = BehovMediator(behovssporer),
-            observatører = listOf(ventendeMeldekort, behandlingMetrikker),
-        )
-
-    private val postgresMeldingRepository = PostgresMeldingRepository(dataSource)
-
-    private val apiRepositoryPostgres = ApiRepositoryPostgres(dataSource, postgresMeldingRepository, behovssporer)
+    private lateinit var runtime: BehandlingRuntime
 
     private val rapidsConnection: RapidsConnection =
         RapidApplication.create(
             env = config,
             builder = {
                 withKtor { preStopHook, rapid ->
+                    runtime =
+                        BehandlingRuntime(
+                            dataSource = dataSource,
+                            rapidsConnection = rapid,
+                            auditlogg = ApiAuditlogg(AktivitetsloggMediator(), rapid),
+                            regelverk = regelverk,
+                        ) { ident: String -> ApiMessageContext(rapid, ident) }
+
                     naisApp(
-                        meterRegistry =
-                        meterRegistry,
+                        meterRegistry = meterRegistry,
                         objectMapper = objectMapper,
                         applicationLogger = LoggerFactory.getLogger("ApplicationLogger"),
                         callLogger = LoggerFactory.getLogger("CallLogger"),
@@ -120,44 +74,13 @@ internal class ApplicationBuilder(
                             dataSource.close()
                             logger.info { "Lukket datasource" }
                         }
-                        behandlingApi(
-                            personRepository = personRepository,
-                            hendelseMediator = hendelseMediator,
-                            auditlogg = ApiAuditlogg(AktivitetsloggMediator(), rapid),
-                            opplysningstyper = opplysningstyper,
-                            apiRepositoryPostgres = apiRepositoryPostgres,
-                            meldekortRepository = meldekortRepositoryPostgres,
-                            meterRegistry,
-                        ) { ident: String -> ApiMessageContext(rapid, ident) }
+                        runtime.api(this)
                         simuleringApi()
                     }
                 }
             },
         ) { engine, rapidsConnection: KafkaRapid ->
-            // Logger bare oppgaver enn så lenge. Bør inn i HendelseMediator
-            ArenaOppgaveMottak(rapidsConnection, SakRepositoryPostgres(dataSource))
-
-            // Vedtak mottak
-            MarkerMeldekortSomBehandletMottak(rapidsConnection, meldekortRepositoryPostgres)
-
-            avklaringRepository.registerObserver(
-                AvklaringKafkaObservatør(
-                    rapidsConnection,
-                ),
-            )
-
-            MessageMediator(
-                rapidsConnection = rapidsConnection,
-                hendelseMediator = hendelseMediator,
-                meldingRepository = postgresMeldingRepository,
-                opplysningstyper = opplysningstyper,
-                meldekortRepository = meldekortRepositoryPostgres,
-                apiRepositoryPostgres = apiRepositoryPostgres,
-                behovssporer = behovssporer,
-                personRepository = personRepository,
-            ).apply {
-                regelverk.forEach { it.registrer(rapidsConnection, this, prosessregister) }
-            }
+            runtime.registrerMottak()
 
             rapidsConnection.register(
                 object : RapidsConnection.StatusListener {
@@ -178,20 +101,13 @@ internal class ApplicationBuilder(
 
     override fun onStartup(rapidsConnection: RapidsConnection) {
         postgresDataSourceBuilder.runMigration()
-        opplysningRepository.lagreOpplysningstyper(opplysningstyper)
+        runtime.lagreOpplysningstyper()
         logger.info { "Starter opp dp-behandling" }
 
-        // Start jobb som sletter fjernet opplysninger
         SlettFjernetOpplysninger.slettOpplysninger(VaktmesterPostgresRepo(dataSource))
 
-        // Start meldekortbehandling
         BehandleMeldekort(
-            MeldekortBehandlingskø(
-                dataSource,
-                personRepository,
-                meldekortRepositoryPostgres,
-                rapidsConnection,
-            ),
+            runtime.meldekortBehandlingskø(rapidsConnection),
         ).start()
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/BehandlingRuntime.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/BehandlingRuntime.kt
@@ -1,0 +1,116 @@
+package no.nav.dagpenger.behandling.mediator
+
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
+import io.ktor.server.application.Application
+import no.nav.dagpenger.behandling.mediator.api.behandlingApi
+import no.nav.dagpenger.behandling.mediator.audit.Auditlogg
+import no.nav.dagpenger.behandling.mediator.meldekort.MeldekortBehandlingskø
+import no.nav.dagpenger.behandling.mediator.melding.PostgresMeldingRepository
+import no.nav.dagpenger.behandling.mediator.mottak.ArenaOppgaveMottak
+import no.nav.dagpenger.behandling.mediator.mottak.MarkerMeldekortSomBehandletMottak
+import no.nav.dagpenger.behandling.mediator.mottak.SakRepositoryPostgres
+import no.nav.dagpenger.behandling.mediator.repository.ApiRepositoryPostgres
+import no.nav.dagpenger.behandling.mediator.repository.AvklaringKafkaObservatør
+import no.nav.dagpenger.behandling.mediator.repository.AvklaringRepositoryPostgres
+import no.nav.dagpenger.behandling.mediator.repository.BehandlingRepositoryPostgres
+import no.nav.dagpenger.behandling.mediator.repository.KildeRepository
+import no.nav.dagpenger.behandling.mediator.repository.MeldekortRepositoryPostgres
+import no.nav.dagpenger.behandling.mediator.repository.OpplysningerRepositoryPostgres
+import no.nav.dagpenger.behandling.mediator.repository.PersonRepository
+import no.nav.dagpenger.behandling.mediator.repository.PersonRepositoryPostgres
+import no.nav.dagpenger.behandling.mediator.repository.VentendeMeldekortDings
+import no.nav.dagpenger.behandling.mediator.utboks.UtboksLagerPostgres
+import no.nav.dagpenger.opplysning.Opplysningstype
+import no.nav.dagpenger.opplysning.Prosessregister
+import no.nav.dagpenger.regelverk.RegelverkRegistrering
+import javax.sql.DataSource
+
+/**
+ * Kapsler all wiring av repositories, mediatorer, mottak og API.
+ * Brukes av ApplicationBuilder i prod og SimulertDagpengerSystem i test.
+ */
+class BehandlingRuntime(
+    private val dataSource: DataSource,
+    val rapidsConnection: RapidsConnection,
+    private val auditlogg: Auditlogg,
+    private val regelverk: List<RegelverkRegistrering>,
+    private val aktivitetsloggMediator: IAktivitetsloggMediator = AktivitetsloggMediator(),
+    private val messageContextFactory: (ident: String) -> MessageContext = { rapidsConnection as MessageContext },
+) {
+    private val opplysningstyper: Set<Opplysningstype<*>> = regelverk.flatMap { it.opplysningstyper }.toSet()
+
+    private val kildeRepository = KildeRepository(dataSource)
+    private val opplysningerRepository = OpplysningerRepositoryPostgres(dataSource, kildeRepository)
+    private val avklaringRepository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
+    private val prosessregister = Prosessregister()
+
+    val personRepository: PersonRepository =
+        PersonRepositoryPostgres(
+            dataSource,
+            BehandlingRepositoryPostgres(
+                dataSource,
+                opplysningerRepository,
+                avklaringRepository,
+                kildeRepository,
+                prosessregister,
+            ),
+        )
+
+    val meldekortRepository = MeldekortRepositoryPostgres(dataSource)
+    private val ventendeMeldekort = VentendeMeldekortDings(meldekortRepository)
+
+    private val behovssporer = Behovssporer(dataSource)
+
+    val hendelseMediator: IHendelseMediator =
+        HendelseMediator(
+            UtboksLagerPostgres(dataSource),
+            personRepository,
+            meldekortRepository,
+            behovMediator = BehovMediator(behovssporer),
+            aktivitetsloggMediator = aktivitetsloggMediator,
+            observatører = listOf(ventendeMeldekort, BehandlingMetrikker()),
+        )
+
+    private val postgresMeldingRepository = PostgresMeldingRepository(dataSource)
+    private val apiRepositoryPostgres = ApiRepositoryPostgres(dataSource, postgresMeldingRepository, behovssporer)
+
+    fun registrerMottak() {
+        ArenaOppgaveMottak(rapidsConnection, SakRepositoryPostgres(dataSource))
+        MarkerMeldekortSomBehandletMottak(rapidsConnection, meldekortRepository)
+
+        avklaringRepository.registerObserver(AvklaringKafkaObservatør(rapidsConnection))
+
+        MessageMediator(
+            rapidsConnection = rapidsConnection,
+            hendelseMediator = hendelseMediator,
+            meldingRepository = postgresMeldingRepository,
+            opplysningstyper = opplysningstyper,
+            meldekortRepository = meldekortRepository,
+            apiRepositoryPostgres = apiRepositoryPostgres,
+            behovssporer = behovssporer,
+            personRepository = personRepository,
+        ).apply {
+            regelverk.forEach { it.registrer(rapidsConnection, this, prosessregister) }
+        }
+    }
+
+    fun lagreOpplysningstyper() {
+        opplysningerRepository.lagreOpplysningstyper(opplysningstyper)
+    }
+
+    val api: Application.() -> Unit = {
+        behandlingApi(
+            personRepository = personRepository,
+            hendelseMediator = hendelseMediator,
+            auditlogg = auditlogg,
+            opplysningstyper = opplysningstyper,
+            apiRepositoryPostgres = apiRepositoryPostgres,
+            meldekortRepository = meldekortRepository,
+            messageContext = messageContextFactory,
+        )
+    }
+
+    fun meldekortBehandlingskø(messageContext: MessageContext) =
+        MeldekortBehandlingskø(dataSource, personRepository, meldekortRepository, messageContext)
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/HendelseMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/HendelseMediator.kt
@@ -50,7 +50,7 @@ internal class HendelseMediator(
     private val personRepository: PersonRepository,
     private val meldekortRepository: MeldekortRepository,
     private val behovMediator: BehovMediator = BehovMediator(),
-    private val aktivitetsloggMediator: AktivitetsloggMediator = AktivitetsloggMediator(),
+    private val aktivitetsloggMediator: IAktivitetsloggMediator = AktivitetsloggMediator(),
     observatører: Collection<PersonObservatør> = emptySet(),
 ) : IHendelseMediator {
     private val observatører = observatører.toSet()
@@ -355,7 +355,7 @@ internal class HendelseMediator(
     }
 }
 
-internal interface IHendelseMediator {
+interface IHendelseMediator {
     fun behandle(
         hendelse: StartHendelse,
         context: MessageContext,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/MessageMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/MessageMediator.kt
@@ -34,7 +34,7 @@ import no.nav.dagpenger.behandling.mediator.mottak.UtbetalingStatusMessage
 import no.nav.dagpenger.behandling.mediator.mottak.UtbetalingStatusMottak
 import no.nav.dagpenger.behandling.mediator.repository.ApiRepositoryPostgres
 import no.nav.dagpenger.behandling.mediator.repository.MeldekortRepository
-import no.nav.dagpenger.behandling.mediator.repository.PersonRepositoryPostgres
+import no.nav.dagpenger.behandling.mediator.repository.PersonRepository
 import no.nav.dagpenger.behandling.modell.hendelser.AvbrytBehandlingHendelse
 import no.nav.dagpenger.behandling.modell.hendelser.AvklaringIkkeRelevantHendelse
 import no.nav.dagpenger.behandling.modell.hendelser.FjernOpplysningHendelse
@@ -56,13 +56,13 @@ import java.util.UUID
 
 internal class MessageMediator(
     rapidsConnection: RapidsConnection,
-    private val hendelseMediator: HendelseMediator,
+    private val hendelseMediator: IHendelseMediator,
     private val meldingRepository: MeldingRepository,
     meldekortRepository: MeldekortRepository,
     private val apiRepositoryPostgres: ApiRepositoryPostgres,
     private val behovssporer: Behovssporer,
     opplysningstyper: Set<Opplysningstype<*>>,
-    personRepository: PersonRepositoryPostgres,
+    personRepository: PersonRepository,
 ) : IMessageMediator {
     init {
         // Generiske mottak

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
@@ -7,35 +7,16 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.OutgoingMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.SentMessage
 import io.ktor.server.application.Application
-import io.mockk.mockk
 import no.nav.dagpenger.behandling.api.models.BehandlingsresultatDTO
 import no.nav.dagpenger.behandling.db.DBTestContext
 import no.nav.dagpenger.behandling.db.Postgres
 import no.nav.dagpenger.behandling.helpers.scenario.assertions.BehandlingsresultatAssertions
-import no.nav.dagpenger.behandling.mediator.BehovMediator
-import no.nav.dagpenger.behandling.mediator.Behovssporer
-import no.nav.dagpenger.behandling.mediator.HendelseMediator
-import no.nav.dagpenger.behandling.mediator.MessageMediator
-import no.nav.dagpenger.behandling.mediator.api.behandlingApi
+import no.nav.dagpenger.behandling.mediator.BehandlingRuntime
+import no.nav.dagpenger.behandling.mediator.IAktivitetsloggMediator
 import no.nav.dagpenger.behandling.mediator.audit.Auditlogg
-import no.nav.dagpenger.behandling.mediator.meldekort.MeldekortBehandlingskø
-import no.nav.dagpenger.behandling.mediator.melding.PostgresMeldingRepository
-import no.nav.dagpenger.behandling.mediator.mottak.MarkerMeldekortSomBehandletMottak
-import no.nav.dagpenger.behandling.mediator.repository.ApiRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.AvklaringKafkaObservatør
-import no.nav.dagpenger.behandling.mediator.repository.AvklaringRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.BehandlingRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.KildeRepository
-import no.nav.dagpenger.behandling.mediator.repository.MeldekortRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.OpplysningerRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.PersonRepositoryPostgres
-import no.nav.dagpenger.behandling.mediator.repository.VentendeMeldekortDings
-import no.nav.dagpenger.behandling.mediator.utboks.UtboksLagerPostgres
 import no.nav.dagpenger.behandling.modell.Ident.Companion.tilPersonIdentfikator
 import no.nav.dagpenger.behandling.modell.Person
 import no.nav.dagpenger.ferietillegg.FerietilleggRegistrering
-import no.nav.dagpenger.opplysning.Opplysningstype
-import no.nav.dagpenger.opplysning.Prosessregister
 import no.nav.dagpenger.regel.DagpengerRegistrering
 import no.nav.dagpenger.regelverk.RegelverkRegistrering
 import org.approvaltests.Approvals
@@ -51,72 +32,35 @@ internal class SimulertDagpengerSystem(
     }
 
     private val rapid = TestRapid()
-    private val kildeRepository = KildeRepository(dbTestContext.dataSource)
-    private val opplysningerRepository = OpplysningerRepositoryPostgres(dbTestContext.dataSource, kildeRepository)
-    private val prosessregister = Prosessregister()
-    private val personRepository =
-        PersonRepositoryPostgres(
-            dbTestContext.dataSource,
-            BehandlingRepositoryPostgres(
-                dbTestContext.dataSource,
-                opplysningerRepository,
-                AvklaringRepositoryPostgres(dbTestContext.dataSource, kildeRepository, listOf(AvklaringKafkaObservatør(rapid))),
-                kildeRepository,
-                prosessregister,
-            ),
-        )
-    private val meldekortRepository = MeldekortRepositoryPostgres(dbTestContext.dataSource)
-    private val ventendeMeldekort = VentendeMeldekortDings(meldekortRepository)
-    private val hendelseMediator =
-        HendelseMediator(
-            postgres = UtboksLagerPostgres(dbTestContext.dataSource),
-            personRepository = personRepository,
-            meldekortRepository = meldekortRepository,
-            behovMediator = BehovMediator(),
-            aktivitetsloggMediator = mockk(relaxed = true),
-            listOf(ventendeMeldekort),
-        )
+    private val regelverk: List<RegelverkRegistrering> = listOf(DagpengerRegistrering(), FerietilleggRegistrering())
 
-    private val postgresMeldingRepository = PostgresMeldingRepository(dbTestContext.dataSource)
-
-    private val behovssporer = Behovssporer(dbTestContext.dataSource)
-    private val apiRepositoryPostgres = ApiRepositoryPostgres(dbTestContext.dataSource, postgresMeldingRepository, behovssporer)
     val auditlogg = TestAuditlogg()
 
-    private val regelverk: List<RegelverkRegistrering> = listOf(DagpengerRegistrering(), FerietilleggRegistrering())
-    private val opplysningstyper: Set<Opplysningstype<*>> = regelverk.flatMap { it.opplysningstyper }.toSet()
+    private val runtime =
+        BehandlingRuntime(
+            dataSource = dbTestContext.dataSource,
+            rapidsConnection = rapid,
+            auditlogg = auditlogg,
+            regelverk = regelverk,
+            aktivitetsloggMediator =
+                object : IAktivitetsloggMediator {
+                    override fun håndter(
+                        context: MessageContext,
+                        hendelse: no.nav.dagpenger.aktivitetslogg.AktivitetsloggHendelse,
+                    ) {}
+                },
+        ) { rapid }
 
     init {
-        MarkerMeldekortSomBehandletMottak(rapid, meldekortRepository)
-        MessageMediator(
-            rapidsConnection = rapid,
-            hendelseMediator = hendelseMediator,
-            meldingRepository = postgresMeldingRepository,
-            meldekortRepository = meldekortRepository,
-            apiRepositoryPostgres = apiRepositoryPostgres,
-            behovssporer = behovssporer,
-            opplysningstyper = opplysningstyper,
-            personRepository = personRepository,
-        ).apply {
-            regelverk.forEach { it.registrer(rapid, this, prosessregister) }
-        }
-        opplysningerRepository.lagreOpplysningstyper(Opplysningstype.definerteTyper)
+        runtime.registrerMottak()
+        runtime.lagreOpplysningstyper()
     }
 
-    val api: Application.() -> Unit = {
-        behandlingApi(
-            personRepository,
-            hendelseMediator,
-            auditlogg,
-            opplysningstyper,
-            apiRepositoryPostgres,
-            meldekortRepository,
-        ) { rapid }
-    }
+    val api: Application.() -> Unit = runtime.api
 
     val person = Mennesket(rapid, oppsett)
     val behovsløsere = Behovsløsere(rapid, person)
-    val saksbehandler = TestSaksbehandler2(person, hendelseMediator, personRepository, rapid)
+    val saksbehandler = TestSaksbehandler2(person, runtime.hendelseMediator, runtime.personRepository, rapid)
 
     val rapidInspektør get() = rapid.inspektør
 
@@ -147,7 +91,7 @@ internal class SimulertDagpengerSystem(
     }
 
     fun BehandlingsresultatDTO.harOpplysning(opplysningId: UUID): Boolean {
-        val behandling = personRepository.hentBehandling(person.behandlingId)
+        val behandling = runtime.personRepository.hentBehandling(person.behandlingId)
         return runCatching { behandling!!.opplysninger.finnOpplysning(opplysningId) }.isSuccess
     }
 
@@ -172,7 +116,7 @@ internal class SimulertDagpengerSystem(
     }
 
     private fun opprettPerson(ident: String) {
-        personRepository.lagre(Person(ident.tilPersonIdentfikator()))
+        runtime.personRepository.lagre(Person(ident.tilPersonIdentfikator()))
     }
 
     class TestRapidMessageContext(
@@ -218,8 +162,7 @@ internal class SimulertDagpengerSystem(
             )
     }
 
-    val meldekortkø =
-        MeldekortBehandlingskø(dbTestContext.dataSource, personRepository, meldekortRepository, TestRapidMessageContext(rapid))
+    val meldekortkø = runtime.meldekortBehandlingskø(TestRapidMessageContext(rapid))
 
     fun meldekortBatch(avklar: Boolean = false) {
         val påbegynteMeldekort = meldekortkø.sendMeldekortTilBehandling()
@@ -230,7 +173,7 @@ internal class SimulertDagpengerSystem(
                 saksbehandler.godkjenn()
 
                 // Marker som ferdig (vi klarer ikke å fange det i VedtakFattetMottak)
-                meldekortRepository.markerSomFerdig(eksternMeldekortId)
+                runtime.meldekortRepository.markerSomFerdig(eksternMeldekortId)
             }
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/TestSaksbehandler2.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/TestSaksbehandler2.kt
@@ -4,7 +4,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.matchers.nulls.shouldNotBeNull
 import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.behandling.api.models.OpplysningerDTO
-import no.nav.dagpenger.behandling.mediator.HendelseMediator
+import no.nav.dagpenger.behandling.mediator.IHendelseMediator
 import no.nav.dagpenger.behandling.mediator.repository.PersonRepository
 import no.nav.dagpenger.behandling.modell.Behandling
 import no.nav.dagpenger.behandling.modell.Ident.Companion.tilPersonIdentfikator
@@ -31,7 +31,7 @@ import java.util.UUID
 
 internal class TestSaksbehandler2(
     private val testPerson: Mennesket,
-    private val hendelseMediator: HendelseMediator,
+    private val hendelseMediator: IHendelseMediator,
     private val personRepository: PersonRepository,
     private val rapid: TestRapid,
 ) {


### PR DESCRIPTION
Trekker ut all wiring-logikk (repositories, mediators, API) til en egen `BehandlingRuntime`-klasse som kan instansieres i tester uten `RapidsConnection`.

## Endringer

- Ny `BehandlingRuntime`-klasse med eksplisitt `DataSource`-parameter
- `IAktivitetsloggMediator`-interface for testbarhet
- `IHendelseMediator` gjort public (var internal)
- `MessageMediator` tar interfaces i stedet for konkrete typer
- `SimulertDagpengerSystem` forenklet til å bruke `BehandlingRuntime`

## Motivasjon

`ApplicationBuilder` hadde for mye ansvar — den var både livssyklus-styring (RapidsConnection, startup/shutdown) og wiring av domenelogikk. Dette gjorde det umulig å teste det faktiske systemet uten å starte hele Rapid-applikasjonen.

`BehandlingRuntime` eier nå all wiring og kan brukes direkte i tester.