### PR TITLE
kan kjøre databasetester i parallell

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.naisful.naisApp
 import com.github.navikt.tbd_libs.rapids_and_rivers.KafkaRapid
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.server.application.ApplicationStopped
 import io.micrometer.core.instrument.Clock
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
@@ -61,7 +60,7 @@ internal class ApplicationBuilder(
 
     private val opplysningstyper: Set<Opplysningstype<*>> = regelverk.flatMap { it.opplysningstyper }.toSet()
     private val postgresDataSourceBuilder = PostgresDataSourceBuilder()
-    private val dataSource = postgresDataSourceBuilder.dataSource
+    private val dataSource = postgresDataSourceBuilder.dbsession
     private val kildeRepository = KildeRepository(dataSource)
     private val avklaringRepository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
     private val opplysningRepository = OpplysningerRepositoryPostgres(dataSource, kildeRepository)
@@ -115,11 +114,6 @@ internal class ApplicationBuilder(
                         preStopHook = preStopHook::handlePreStopRequest,
                         statusPagesConfig = { statusPagesConfig() },
                     ) {
-                        monitor.subscribe(ApplicationStopped) {
-                            logger.info { "Forsøker å lukke datasource..." }
-                            dataSource.close()
-                            logger.info { "Lukket datasource" }
-                        }
                         behandlingApi(
                             personRepository = personRepository,
                             hendelseMediator = hendelseMediator,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/Behovssporer.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/Behovssporer.kt
@@ -3,12 +3,11 @@ package no.nav.dagpenger.behandling.mediator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.prometheus.metrics.core.metrics.GaugeWithCallback
 import kotliquery.queryOf
-import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import java.util.UUID
-import javax.sql.DataSource
 
 internal class Behovssporer(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
 ) {
     companion object {
         private val logger = KotlinLogging.logger { }
@@ -29,7 +28,7 @@ internal class Behovssporer(
         kilde: Kilde,
     ) {
         if (behov.isEmpty()) return
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction { tx ->
                 behov.forEach { behovNavn ->
                     tx.run(
@@ -61,7 +60,7 @@ internal class Behovssporer(
         vararg behov: String,
     ) {
         if (behov.isEmpty()) return
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction { tx ->
                 behov.forEach { behovNavn ->
                     // Hent opprettet-tidspunkt og kilde for histogram
@@ -109,7 +108,7 @@ internal class Behovssporer(
     }
 
     fun hentAktiveBehov(behandlingId: UUID): List<AktivtBehov> =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.run(
                 queryOf(
                     // language=PostgreSQL
@@ -146,7 +145,7 @@ internal class Behovssporer(
                 .labelNames("behov", "kilde")
                 .callback { callback ->
                     try {
-                        sessionOf(dataSource).use { session ->
+                        dbSession.session { session ->
                             session.run(
                                 queryOf(
                                     // language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/db/DatabaseSession.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/db/DatabaseSession.kt
@@ -1,0 +1,73 @@
+package no.nav.dagpenger.behandling.mediator.db
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotliquery.Session
+import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.repository.DbMetrics
+import no.nav.dagpenger.behandling.mediator.repository.PostgresUnitOfWork
+import java.sql.Connection
+import javax.sql.DataSource
+
+private val dbLogger = KotlinLogging.logger {}
+
+/**
+ * [dataSource] er [Lazy] slik at vi utsetter oppretting av connection pool til første spørring.
+ * Da unngår vi at applikasjonen kobler seg til databasen ved oppstart, før den faktisk trengs
+ * (f.eks. i tester eller komponenter som ikke alltid leser/skriver).
+ */
+data class DatabaseSession(
+    private val dataSource: Lazy<DataSource>,
+) {
+    fun <R> session(block: (Session) -> R): R = sessionOf(dataSource.value).use(block)
+
+    fun transaction(transactionBlock: PostgresUnitOfWork.() -> Unit) {
+        session { session ->
+            session.connection.underlying.withTransaction {
+                PostgresUnitOfWork(session).apply(transactionBlock)
+            }
+        }
+    }
+}
+
+private fun <R> Connection.withTransaction(transactionBlock: () -> R): R {
+    val transactionTimer = DbMetrics.transactionDuration.startTimer()
+    val previousValue = autoCommit
+    autoCommit = false
+    try {
+        DbMetrics.activeTransactions.inc()
+
+        val result = transactionBlock()
+
+        commitAndCount()
+
+        return result
+    } catch (err: Exception) {
+        rollbackAndCount()
+        dbLogger.error(err) { "Transaksjonen feilet, ruller tilbake" }
+        throw err
+    } finally {
+        autoCommit = previousValue
+        DbMetrics.activeTransactions.dec()
+        transactionTimer.observeDuration()
+    }
+}
+
+private fun Connection.commitAndCount() {
+    val commitTimer = DbMetrics.commitDuration.startTimer()
+    try {
+        commit()
+        DbMetrics.commitCounter.inc()
+    } finally {
+        commitTimer.observeDuration()
+    }
+}
+
+private fun Connection.rollbackAndCount() {
+    val timer = DbMetrics.transactionDuration.startTimer()
+    try {
+        rollback()
+        DbMetrics.rollbackCounter.inc()
+    } finally {
+        timer.observeDuration()
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/db/PostgresDataSourceBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/db/PostgresDataSourceBuilder.kt
@@ -51,7 +51,7 @@ internal class PostgresDataSourceBuilder {
         }
     }
 
-    val dataSource by lazy { HikariDataSource(hikariConfig) }
+    val dbsession = DatabaseSession(lazy { HikariDataSource(hikariConfig) })
 
     internal fun runMigration() {
         val config =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/meldekort/MeldekortBehandlingskø.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/meldekort/MeldekortBehandlingskø.kt
@@ -4,18 +4,17 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
-import kotliquery.sessionOf
 import no.nav.dagpenger.behandling.mediator.BehandlingMetrikker.Companion.meldekortKøStørrelse
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.db.medLås
 import no.nav.dagpenger.behandling.mediator.repository.MeldekortRepository
 import no.nav.dagpenger.behandling.mediator.repository.PersonRepository
 import no.nav.dagpenger.behandling.modell.Ident.Companion.tilPersonIdentfikator
 import no.nav.dagpenger.behandling.modell.hendelser.MeldekortId
 import java.time.LocalDate
-import javax.sql.DataSource
 
 class MeldekortBehandlingskø(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
     private val personRepositoryPostgres: PersonRepository,
     private val meldekortRepository: MeldekortRepository,
     private val rapid: MessageContext,
@@ -27,7 +26,7 @@ class MeldekortBehandlingskø(
 
     fun sendMeldekortTilBehandling(kjøringsdato: LocalDate = LocalDate.now()): List<MeldekortId> {
         val begynteMeldekort = mutableListOf<MeldekortId>()
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction { tx ->
                 tx.medLås(LÅSE_NØKKEL) {
                     do {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/melding/PostgresMeldingRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/melding/PostgresMeldingRepository.kt
@@ -3,7 +3,7 @@ package no.nav.dagpenger.behandling.mediator.melding
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.mottak.AvbrytBehandlingMessage
 import no.nav.dagpenger.behandling.mediator.mottak.AvklaringIkkeRelevantMessage
 import no.nav.dagpenger.behandling.mediator.mottak.BehandlingStårFastMessage
@@ -24,10 +24,9 @@ import no.nav.dagpenger.regelverk.melding.Melding
 import no.nav.dagpenger.regelverk.melding.MeldingRepository
 import org.postgresql.util.PGobject
 import java.util.UUID
-import javax.sql.DataSource
 
 internal class PostgresMeldingRepository(
-    val dataSource: DataSource,
+    val dbSession: DatabaseSession,
 ) : MeldingRepository {
     override fun lagreMelding(
         melding: Melding,
@@ -37,7 +36,7 @@ internal class PostgresMeldingRepository(
     ) {
         val hendelseType = meldingType(melding) ?: return
 
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction { transactionalSession: TransactionalSession ->
                 transactionalSession.run(
                     queryOf(
@@ -68,7 +67,7 @@ internal class PostgresMeldingRepository(
     }
 
     override fun markerSomBehandlet(meldingId: UUID) =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -85,7 +84,7 @@ internal class PostgresMeldingRepository(
         }
 
     override fun erBehandlet(meldingId: UUID): Boolean =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/ArenaOppgaveMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/ArenaOppgaveMottak.kt
@@ -11,14 +11,13 @@ import io.github.oshai.kotlinlogging.withLoggingContext
 import io.micrometer.core.instrument.MeterRegistry
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import kotliquery.queryOf
-import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.mottak.SakRepository.Behandling
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType
 import no.nav.dagpenger.regel.OpplysningsTyper
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
-import javax.sql.DataSource
 
 internal class ArenaOppgaveMottak(
     rapidsConnection: RapidsConnection,
@@ -139,10 +138,10 @@ interface SakRepository {
 }
 
 internal class SakRepositoryPostgres(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
 ) : SakRepository {
     override fun finnBehandling(fagsakId: Int): Behandling? =
-        sessionOf(dataSource).use {
+        dbSession.session {
             it.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/ApiRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/ApiRepositoryPostgres.kt
@@ -4,9 +4,9 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.behandling.mediator.Behovssporer
 import no.nav.dagpenger.behandling.mediator.Metrikk.tidBruktPerEndring
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType.ForslagTilVedtak
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType.TilGodkjenning
@@ -16,7 +16,6 @@ import no.nav.dagpenger.uuid.UUIDv7
 import java.time.LocalDateTime
 import java.util.UUID
 import java.util.concurrent.TimeoutException
-import javax.sql.DataSource
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -34,7 +33,7 @@ internal class ApiMelding(
 }
 
 internal class ApiRepositoryPostgres(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
     private val meldingRepository: MeldingRepository,
     private val behovssporer: Behovssporer,
     private val timout: Duration = 15.seconds,
@@ -70,7 +69,7 @@ internal class ApiRepositoryPostgres(
         } catch (e: Exception) {
             logger.info { "Fikk feil under endring for behandlingId=$behandlingId, behov=$behov" }
             // Marker behovet som feilet
-            sessionOf(dataSource).use { session ->
+            dbSession.session { session ->
                 session.run {
                     queryOf(
                         // language=PostgreSQL
@@ -135,7 +134,7 @@ internal class ApiRepositoryPostgres(
     private fun getStatus(
         behandlingId: UUID,
         behov: String,
-    ) = sessionOf(dataSource).use { session ->
+    ) = dbSession.session { session ->
         session.run(
             queryOf(
                 // language=PostgreSQL
@@ -150,7 +149,7 @@ internal class ApiRepositoryPostgres(
     }
 
     private fun hentBehandlingSistEndret(behandlingId: UUID) =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session
                 .run(
                     queryOf(
@@ -168,7 +167,7 @@ internal class ApiRepositoryPostgres(
     private fun hentBehandlingTilstand(
         behandlingId: UUID,
         sistEndret: LocalDateTime,
-    ) = sessionOf(dataSource).use { session ->
+    ) = dbSession.session { session ->
         session
             .run(
                 queryOf(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgres.kt
@@ -1,11 +1,11 @@
 package no.nav.dagpenger.behandling.mediator.repository
 
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.avklaring.Avklaring.Endring.Avbrutt
 import no.nav.dagpenger.avklaring.Avklaring.Endring.Avklart
 import no.nav.dagpenger.avklaring.Avklaring.Endring.UnderBehandling
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.objectMapper
 import no.nav.dagpenger.behandling.mediator.repository.AvklaringRepositoryObserver.NyAvklaringHendelse
 import no.nav.dagpenger.behandling.mediator.repository.JsonSerde.Companion.serde
@@ -17,10 +17,9 @@ import no.nav.dagpenger.opplysning.Saksbehandlerkilde
 import no.nav.dagpenger.uuid.UUIDv7
 import java.time.LocalDateTime
 import java.util.UUID
-import javax.sql.DataSource
 
 internal class AvklaringRepositoryPostgres(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
     private val kildeRepository: KildeRepository,
     observatører: List<AvklaringRepositoryObserver> = emptyList(),
 ) : AvklaringRepository {
@@ -35,7 +34,7 @@ internal class AvklaringRepositoryPostgres(
     override fun hentAvklaringer(behandlingIder: Set<UUID>): Map<UUID, List<Avklaring>> {
         if (behandlingIder.isEmpty()) return emptyMap()
 
-        return sessionOf(dataSource).use { session ->
+        return dbSession.session { session ->
             val avklaringer =
                 session.run(
                     queryOf(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgres.kt
@@ -2,9 +2,9 @@ package no.nav.dagpenger.behandling.mediator.repository
 
 import kotliquery.Session
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.behandling.mediator.Metrikk.hentBehandlingTimer
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.repository.OpplysningerRepositoryPostgres.Companion.hentOpplysninger
 import no.nav.dagpenger.behandling.modell.Arbeidssteg
 import no.nav.dagpenger.behandling.modell.Behandling
@@ -19,13 +19,12 @@ import no.nav.dagpenger.opplysning.Prosessregister
 import no.nav.dagpenger.opplysning.Saksbehandler
 import java.time.LocalDate
 import java.util.UUID
-import javax.sql.DataSource
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.groupBy
 
 internal class BehandlingRepositoryPostgres(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
     private val opplysningRepository: OpplysningerRepository,
     private val avklaringRepository: AvklaringRepository,
     private val kildeRepository: KildeRepository,
@@ -34,13 +33,13 @@ internal class BehandlingRepositoryPostgres(
     AvklaringRepository by avklaringRepository {
     override fun hentBehandling(behandlingId: UUID): Behandling? =
         hentBehandlingTimer.time<Behandling?> {
-            sessionOf(dataSource).use { session ->
+            dbSession.session { session ->
                 session.hentBehandling(behandlingId)
             }
         }
 
     override fun hentBehandlinger(ident: Ident): List<Behandlingkjede> =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.hentBehandlinger(HentBehandling.AlleForIdent(ident))
         }
 
@@ -48,7 +47,7 @@ internal class BehandlingRepositoryPostgres(
         behandlingId: UUID,
         nyBasertPåId: UUID?,
     ) {
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -297,7 +296,7 @@ internal class BehandlingRepositoryPostgres(
         fraOgMed: LocalDate,
         tilOgMed: LocalDate,
         block: (Behandling) -> Unit,
-    ) = sessionOf(dataSource).use { session ->
+    ) = dbSession.session { session ->
         session.forEach(
             queryOf(
                 // language="PostgreSQL"
@@ -550,7 +549,7 @@ internal class BehandlingRepositoryPostgres(
         opplysningId: UUID,
         begrunnelse: String,
     ) {
-        sessionOf(dataSource).use {
+        dbSession.session {
             val kildeId =
                 it.run(
                     queryOf(
@@ -571,7 +570,7 @@ internal class BehandlingRepositoryPostgres(
     }
 
     override fun lagreUtbetalingStatus(utbetalingStatus: UtbetalingStatus) {
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction {
                 it.run(
                     queryOf(
@@ -593,9 +592,9 @@ internal class BehandlingRepositoryPostgres(
         }
     }
 
-    override fun hentUtbetalingStatus(behandlingId: UUID): UtbetalingStatus.Status {
-        sessionOf(dataSource).use { session ->
-            return session
+    override fun hentUtbetalingStatus(behandlingId: UUID): UtbetalingStatus.Status =
+        dbSession.session { session ->
+            session
                 .run(
                     queryOf(
                         //language=PostgreSQL
@@ -611,5 +610,4 @@ internal class BehandlingRepositoryPostgres(
                 )?.let { UtbetalingStatus.Status.valueOf(it) }
                 ?: throw IllegalArgumentException("Fant ikke utbetalingstatus for behandling $behandlingId")
         }
-    }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/KildeRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/KildeRepository.kt
@@ -3,23 +3,22 @@ package no.nav.dagpenger.behandling.mediator.repository
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import kotliquery.Session
 import kotliquery.queryOf
-import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.opplysning.Kilde
 import no.nav.dagpenger.opplysning.Saksbehandler
 import no.nav.dagpenger.opplysning.Saksbehandlerbegrunnelse
 import no.nav.dagpenger.opplysning.Saksbehandlerkilde
 import no.nav.dagpenger.opplysning.Systemkilde
 import java.util.UUID
-import javax.sql.DataSource
 
 internal class KildeRepository(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
 ) {
     @WithSpan
     fun hentKilde(uuid: UUID): Kilde? = hentKilder(listOf(uuid))[uuid]
 
     @WithSpan
-    fun hentKilder(uuid: List<UUID>): Map<UUID, Kilde> = sessionOf(dataSource).use { hentKilder(uuid, it) }
+    fun hentKilder(uuid: List<UUID>): Map<UUID, Kilde> = dbSession.session { hentKilder(uuid, it) }
 
     @WithSpan
     fun hentKilder(
@@ -156,22 +155,21 @@ internal class KildeRepository(
         kildeId: UUID,
         begrunnelse: String,
     ) {
-        sessionOf(dataSource)
-            .use { session ->
-                session.run(
-                    queryOf(
-                        //language=PostgreSQL
-                        """
-                        UPDATE kilde_saksbehandler 
-                        SET begrunnelse = :begrunnelse, begrunnelse_sist_endret = NOW() 
-                        WHERE kilde_id = :kildeId
-                        """.trimIndent(),
-                        mapOf(
-                            "kildeId" to kildeId,
-                            "begrunnelse" to begrunnelse,
-                        ),
-                    ).asUpdate,
-                )
-            }
+        dbSession.session { session ->
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    """
+                    UPDATE kilde_saksbehandler 
+                    SET begrunnelse = :begrunnelse, begrunnelse_sist_endret = NOW() 
+                    WHERE kilde_id = :kildeId
+                    """.trimIndent(),
+                    mapOf(
+                        "kildeId" to kildeId,
+                        "begrunnelse" to begrunnelse,
+                    ),
+                ).asUpdate,
+            )
+        }
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/MeldekortRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/MeldekortRepositoryPostgres.kt
@@ -3,10 +3,9 @@ package no.nav.dagpenger.behandling.mediator.repository
 import kotliquery.Row
 import kotliquery.Session
 import kotliquery.queryOf
-import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.repository.MeldekortRepository.Meldekortkø
 import no.nav.dagpenger.behandling.mediator.repository.MeldekortRepository.Meldekortstatus
-import no.nav.dagpenger.behandling.mediator.repository.PostgresUnitOfWork.Companion.transaction
 import no.nav.dagpenger.behandling.modell.BehandlingObservatør
 import no.nav.dagpenger.behandling.modell.PersonObservatør
 import no.nav.dagpenger.behandling.modell.hendelser.AktivitetType
@@ -20,14 +19,13 @@ import org.postgresql.util.PGobject
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
-import javax.sql.DataSource
 import kotlin.time.Duration.Companion.seconds
 
 class MeldekortRepositoryPostgres(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
 ) : MeldekortRepository {
     override fun lagre(meldekort: Meldekort) {
-        transaction(dataSource) {
+        dbSession.transaction {
             lagreMeldekort(meldekort)
 
             meldekort.korrigeringAv?.let { korrigertMeldekortId ->
@@ -45,7 +43,7 @@ class MeldekortRepositoryPostgres(
         val førsteVirkedag = finnFørsteArbeidsdag(kjøringsdato)
 
         val meldekort =
-            sessionOf(dataSource).use { session ->
+            dbSession.session { session ->
                 val meldekortUtenDager =
                     session.run(
                         queryOf(
@@ -93,7 +91,7 @@ class MeldekortRepositoryPostgres(
     }
 
     override fun hent(meldekortId: UUID) =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             val meldekortUtenDager =
                 session.run(
                     queryOf(
@@ -107,12 +105,12 @@ class MeldekortRepositoryPostgres(
                     ).map { row ->
                         row.meldekort()
                     }.asSingle,
-                ) ?: return@use null
+                ) ?: return@session null
             session.medDager(listOf(meldekortUtenDager)).single()
         }
 
     override fun hentKorrigeringer(originale: List<MeldekortId>): List<Meldekort> =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             val meldekortUtenDager =
                 session.run(
                     queryOf(
@@ -131,7 +129,7 @@ class MeldekortRepositoryPostgres(
         }
 
     override fun behandlingStartet(meldekortId: MeldekortId) {
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction { tx ->
                 tx.run(
                     queryOf(
@@ -150,7 +148,7 @@ class MeldekortRepositoryPostgres(
     }
 
     override fun markerSomFerdig(meldekortId: MeldekortId) {
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction { tx ->
                 tx.run(
                     queryOf(
@@ -169,7 +167,7 @@ class MeldekortRepositoryPostgres(
     }
 
     override fun settPåVent(meldekortId: MeldekortId) {
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction { tx ->
                 tx.run(
                     queryOf(
@@ -188,7 +186,7 @@ class MeldekortRepositoryPostgres(
     }
 
     override fun sluttMedDerreVentegreieneNåDa(ident: String) {
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.transaction { tx ->
                 tx.run(
                     queryOf(
@@ -206,7 +204,7 @@ class MeldekortRepositoryPostgres(
     }
 
     override fun harMeldekort(eksternMeldekortId: MeldekortId): Boolean =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session
                 .run(
                     queryOf(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgres.kt
@@ -5,7 +5,7 @@ import io.opentelemetry.instrumentation.annotations.WithSpan
 import kotliquery.Row
 import kotliquery.Session
 import kotliquery.queryOf
-import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.objectMapper
 import no.nav.dagpenger.behandling.mediator.repository.JsonSerde.Companion.serde
 import no.nav.dagpenger.opplysning.BarnDatatype
@@ -40,11 +40,10 @@ import org.postgresql.util.PGobject
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
-import javax.sql.DataSource
 import no.nav.dagpenger.inntekt.v1.Inntekt as InntektV1
 
 internal class OpplysningerRepositoryPostgres(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
     private val kildeRepository: KildeRepository,
 ) : OpplysningerRepository {
     internal companion object {
@@ -79,11 +78,10 @@ internal class OpplysningerRepositoryPostgres(
     }
 
     override fun hentOpplysninger(opplysningerId: UUID) =
-        sessionOf(dataSource)
-            .use { session -> return@use session.hentOpplysninger(kildeRepository, opplysningerId) }
+        dbSession.session { session -> session.hentOpplysninger(kildeRepository, opplysningerId) }
 
     override fun lagreOpplysninger(opplysninger: Opplysninger) {
-        PostgresUnitOfWork.transaction(dataSource) {
+        dbSession.transaction {
             lagreOpplysninger(listOf(opplysninger), this)
         }
     }
@@ -120,7 +118,7 @@ internal class OpplysningerRepositoryPostgres(
     }
 
     override fun lagreOpplysningstyper(opplysningstyper: Collection<Opplysningstype<*>>) =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             BatchStatement(
                 //language=PostgreSQL
                 """

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/PersonRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/PersonRepositoryPostgres.kt
@@ -5,21 +5,20 @@ import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.prometheus.metrics.model.snapshots.Labels
 import kotliquery.Session
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.behandling.mediator.Metrikk
 import no.nav.dagpenger.behandling.mediator.Metrikk.hentPersonTimer
 import no.nav.dagpenger.behandling.mediator.Metrikk.lagrePersonMetrikk
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.modell.Ident
 import no.nav.dagpenger.behandling.modell.Person
 import no.nav.dagpenger.behandling.modell.Rettighetstatus
 import no.nav.dagpenger.opplysning.TemporalCollection
 import java.time.LocalDate
-import javax.sql.DataSource
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 
 class PersonRepositoryPostgres(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
     private val behandlingRepository: BehandlingRepository,
 ) : PersonRepository,
     BehandlingRepository by behandlingRepository {
@@ -29,7 +28,7 @@ class PersonRepositoryPostgres(
 
     @WithSpan
     override fun hent(ident: Ident) =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             val timer = TimeSource.Monotonic.markNow()
             session
                 .run(
@@ -65,11 +64,11 @@ class PersonRepositoryPostgres(
 
     @WithSpan
     override fun rettighetstatusFor(ident: Ident): TemporalCollection<Rettighetstatus> =
-        sessionOf(dataSource).use { session -> session.rettighetstatusFor(ident) }
+        dbSession.session { session -> session.rettighetstatusFor(ident) }
 
     @WithSpan
     override fun harIdent(ident: Ident): Boolean =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session
                 .run(
                     queryOf(
@@ -107,7 +106,7 @@ class PersonRepositoryPostgres(
 
     override fun lagre(person: Person) {
         lagrePersonMetrikk.time {
-            PostgresUnitOfWork.transaction(dataSource) {
+            dbSession.transaction {
                 lagre(person, this)
             }
         }
@@ -140,7 +139,7 @@ class PersonRepositoryPostgres(
     }
 
     override fun hentIdenterMedRettighetsperioder(år: Int): List<String> =
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session
                 .run(
                     queryOf(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/PostgresUnitOfWork.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/PostgresUnitOfWork.kt
@@ -1,69 +1,7 @@
 package no.nav.dagpenger.behandling.mediator.repository
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import kotliquery.Session
-import kotliquery.sessionOf
-import java.sql.Connection
-import javax.sql.DataSource
-
-private val logger = KotlinLogging.logger {}
 
 data class PostgresUnitOfWork(
     val session: Session,
-) {
-    companion object {
-        fun transaction(
-            dataSource: DataSource,
-            transactionBlock: PostgresUnitOfWork.() -> Unit,
-        ) {
-            sessionOf(dataSource).use { session ->
-                session.connection.underlying.withTransaction {
-                    PostgresUnitOfWork(session).apply(transactionBlock)
-                }
-            }
-        }
-    }
-}
-
-private fun <R> Connection.withTransaction(transactionBlock: () -> R): R {
-    val transactionTimer = DbMetrics.transactionDuration.startTimer()
-    val previousValue = autoCommit
-    autoCommit = false
-    try {
-        DbMetrics.activeTransactions.inc()
-
-        val result = transactionBlock()
-
-        commitAndCount()
-
-        return result
-    } catch (err: Exception) {
-        rollbackAndCount()
-        logger.error(err) { "Transaksjonen feilet, ruller tilbake" }
-        throw err
-    } finally {
-        autoCommit = previousValue
-        DbMetrics.activeTransactions.dec()
-        transactionTimer.observeDuration()
-    }
-}
-
-private fun Connection.commitAndCount() {
-    val commitTimer = DbMetrics.commitDuration.startTimer()
-    try {
-        commit()
-        DbMetrics.commitCounter.inc()
-    } finally {
-        commitTimer.observeDuration()
-    }
-}
-
-private fun Connection.rollbackAndCount() {
-    val timer = DbMetrics.transactionDuration.startTimer()
-    try {
-        rollback()
-        DbMetrics.rollbackCounter.inc()
-    } finally {
-        timer.observeDuration()
-    }
-}
+)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/VaktmesterPostgresRepo.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/VaktmesterPostgresRepo.kt
@@ -4,13 +4,12 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.db.medLås
 import java.util.UUID
-import javax.sql.DataSource
 
 internal class VaktmesterPostgresRepo(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
 ) {
     companion object {
         private val låsenøkkel = 121212
@@ -22,7 +21,7 @@ internal class VaktmesterPostgresRepo(
         val rapport =
             try {
                 logger.info { "Skal finne kandidater til sletting, med øvre grense på $antallBehandlinger" }
-                sessionOf(dataSource).use { session ->
+                dbSession.session { session ->
                     logger.info { "Har opprettet session" }
                     session.transaction { tx ->
                         logger.info { "Har startet transaksjon" }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/utboks/UtboksLagerPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/utboks/UtboksLagerPostgres.kt
@@ -1,14 +1,13 @@
 package no.nav.dagpenger.behandling.mediator.utboks
 
 import kotliquery.queryOf
-import kotliquery.sessionOf
-import javax.sql.DataSource
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 
 class UtboksLagerPostgres(
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
 ) : UtboksLager {
     override fun lagre(melding: String) {
-        sessionOf(dataSource).use {
+        dbSession.session {
             it.run(
                 queryOf(
                     //language=PostgreSQL

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/TestOpplysningstyper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/TestOpplysningstyper.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.behandling
 
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.repository.KildeRepository
 import no.nav.dagpenger.behandling.mediator.repository.OpplysningerRepositoryPostgres
 import no.nav.dagpenger.opplysning.BarnDatatype
@@ -14,7 +15,6 @@ import no.nav.dagpenger.opplysning.Penger
 import no.nav.dagpenger.opplysning.PeriodeDataType
 import no.nav.dagpenger.opplysning.Tekst
 import no.nav.dagpenger.uuid.UUIDv7
-import javax.sql.DataSource
 
 internal object TestOpplysningstyper {
     val baseOpplysningstype = Opplysningstype.dato(Opplysningstype.Id(UUIDv7.ny(), Dato), "Base")
@@ -44,7 +44,7 @@ internal object TestOpplysningstyper {
     val beløpA = Opplysningstype.beløp(Opplysningstype.Id(UUIDv7.ny(), Penger), "BeløpA")
     val beløpB = Opplysningstype.beløp(Opplysningstype.Id(UUIDv7.ny(), Penger), "BeløpB")
 
-    fun opplysningerRepository(dataSource: DataSource): OpplysningerRepositoryPostgres =
+    fun opplysningerRepository(dataSource: DatabaseSession): OpplysningerRepositoryPostgres =
         OpplysningerRepositoryPostgres(dataSource, KildeRepository(dataSource)).apply {
             lagreOpplysningstyper(definerteTyper)
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/Postgres.kt
@@ -40,6 +40,7 @@ internal object Postgres {
             hikariConfig.copyStateTo(this)
         }
 
+    private val dataSource = lazy { HikariDataSource(hikariConfig) }
     private val flywayDataSource by lazy { HikariDataSource(flywayConfig) }
 
     private val flyWay by lazy {
@@ -59,7 +60,7 @@ internal object Postgres {
     }
 
     inline fun withCleanDb(block: DBTestContext.() -> Unit) {
-        val context = DBTestContext(DatabaseSession(lazy { HikariDataSource(hikariConfig) }), flyWay)
+        val context = DBTestContext(DatabaseSession(dataSource), flyWay)
         context.clean()
         block(context)
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/Postgres.kt
@@ -2,14 +2,28 @@ package no.nav.dagpenger.behandling.db
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import org.flywaydb.core.Flyway
 import org.testcontainers.postgresql.PostgreSQLContainer
+import java.time.Duration
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
+import javax.sql.DataSource
 
 data class DBTestContext(
     val dbSession: DatabaseSession,
-    val flyWay: Flyway,
+    private val flywayDataSource: Lazy<DataSource>,
 ) {
+    private val flyWay by lazy {
+        Flyway
+            .configure()
+            .connectRetries(10)
+            .dataSource(flywayDataSource.value)
+            .cleanDisabled(false)
+            .load()
+    }
+
     fun clean() {
         flyWay.clean()
     }
@@ -21,46 +35,75 @@ data class DBTestContext(
             .size
 }
 
+private val ANTALL_TESTER_I_PARALLELL = System.getProperty("junit.jupiter.execution.parallel.config.fixed.parallelism")?.toInt() ?: 1
+
 internal object Postgres {
-    val instance by lazy {
+    private val logger = KotlinLogging.logger { }
+    private val instance by lazy {
         PostgreSQLContainer("postgres:18.0").apply {
             withReuse(true)
             start()
         }
     }
 
-    private val hikariConfig =
-        HikariConfig().apply {
-            jdbcUrl = instance.jdbcUrl
-            username = instance.username
-            password = instance.password
-        }
-    private val flywayConfig =
-        HikariConfig().apply {
-            hikariConfig.copyStateTo(this)
-        }
+    private val tilgjengeligeTestsesjoner =
+        ArrayBlockingQueue(ANTALL_TESTER_I_PARALLELL, false, opprettInitielleTilkoblinger(ANTALL_TESTER_I_PARALLELL))
 
-    private val dataSource = lazy { HikariDataSource(hikariConfig) }
-    private val flywayDataSource by lazy { HikariDataSource(flywayConfig) }
-
-    private val flyWay by lazy {
-        Flyway
-            .configure()
-            .connectRetries(10)
-            .dataSource(flywayDataSource)
-            .cleanDisabled(false)
-            .load()
-    }
-
-    inline fun withMigratedDb(block: DBTestContext.() -> Unit) {
-        withCleanDb {
-            runMigration()
-            block()
+    fun withTestContext(block: (DBTestContext) -> Unit) {
+        logger.info { "Tester venter på ledig database..." }
+        val testContext =
+            tilgjengeligeTestsesjoner.poll(Duration.ofSeconds(20).toSeconds(), TimeUnit.SECONDS) ?: error("Fikk ikke tak i databasesesjon!")
+        try {
+            logger.info { "Fikk tak i database..." }
+            block(testContext)
+        } finally {
+            logger.info { "Gir databasen tilbake..." }
+            tilgjengeligeTestsesjoner.offer(testContext)
         }
     }
 
-    inline fun withCleanDb(block: DBTestContext.() -> Unit) {
-        val context = DBTestContext(DatabaseSession(dataSource), flyWay)
+    private fun opprettInitielleTilkoblinger(antall: Int): List<DBTestContext> =
+        (1..antall)
+            .map { "testdb_$it" }
+            .map { databasenavn ->
+                logger.info { "Initialiserer $databasenavn" }
+                logger.info { "oppretter db for $databasenavn" }
+                instance.createConnection("").use { conn ->
+                    conn.createStatement().execute("create database $databasenavn")
+                }
+                logger.info { "oppretter testsesjon for $databasenavn" }
+                createTestSession(instance.withDatabaseName(databasenavn))
+            }
+
+    private fun createTestSession(instance: PostgreSQLContainer): DBTestContext {
+        val hikariConfig =
+            HikariConfig().apply {
+                jdbcUrl = instance.jdbcUrl
+                username = instance.username
+                password = instance.password
+                maximumPoolSize = 4
+            }
+        val flywayConfig =
+            HikariConfig().apply {
+                hikariConfig.copyStateTo(this)
+            }
+
+        val dataSource = lazy { HikariDataSource(hikariConfig) }
+        val flywayDataSource = lazy { HikariDataSource(flywayConfig) }
+
+        return DBTestContext(DatabaseSession(dataSource), flywayDataSource)
+    }
+}
+
+internal inline fun withMigratedDb(crossinline block: DBTestContext.() -> Unit) {
+    withCleanDb {
+        runMigration()
+        block()
+    }
+}
+
+internal inline fun withCleanDb(crossinline block: DBTestContext.() -> Unit) {
+    Postgres.withTestContext { context ->
         context.clean()
         block(context)
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/Postgres.kt
@@ -2,12 +2,12 @@ package no.nav.dagpenger.behandling.db
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import org.flywaydb.core.Flyway
 import org.testcontainers.postgresql.PostgreSQLContainer
-import javax.sql.DataSource
 
 data class DBTestContext(
-    val dataSource: DataSource,
+    val dbSession: DatabaseSession,
     val flyWay: Flyway,
 ) {
     fun clean() {
@@ -40,7 +40,6 @@ internal object Postgres {
             hikariConfig.copyStateTo(this)
         }
 
-    private val dataSource by lazy { HikariDataSource(hikariConfig) }
     private val flywayDataSource by lazy { HikariDataSource(flywayConfig) }
 
     private val flyWay by lazy {
@@ -60,7 +59,7 @@ internal object Postgres {
     }
 
     inline fun withCleanDb(block: DBTestContext.() -> Unit) {
-        val context = DBTestContext(dataSource, flyWay)
+        val context = DBTestContext(DatabaseSession(lazy { HikariDataSource(hikariConfig) }), flyWay)
         context.clean()
         block(context)
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/PostgresMigrationTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/db/PostgresMigrationTest.kt
@@ -1,7 +1,6 @@
 package no.nav.dagpenger.behandling.db
 
 import io.kotest.matchers.ints.shouldBeExactly
-import no.nav.dagpenger.behandling.db.Postgres.withCleanDb
 import org.junit.jupiter.api.Test
 
 class PostgresMigrationTest {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
@@ -51,25 +51,25 @@ internal class SimulertDagpengerSystem(
     }
 
     private val rapid = TestRapid()
-    private val kildeRepository = KildeRepository(dbTestContext.dataSource)
-    private val opplysningerRepository = OpplysningerRepositoryPostgres(dbTestContext.dataSource, kildeRepository)
+    private val kildeRepository = KildeRepository(dbTestContext.dbSession)
+    private val opplysningerRepository = OpplysningerRepositoryPostgres(dbTestContext.dbSession, kildeRepository)
     private val prosessregister = Prosessregister()
     private val personRepository =
         PersonRepositoryPostgres(
-            dbTestContext.dataSource,
+            dbTestContext.dbSession,
             BehandlingRepositoryPostgres(
-                dbTestContext.dataSource,
+                dbTestContext.dbSession,
                 opplysningerRepository,
-                AvklaringRepositoryPostgres(dbTestContext.dataSource, kildeRepository, listOf(AvklaringKafkaObservatør(rapid))),
+                AvklaringRepositoryPostgres(dbTestContext.dbSession, kildeRepository, listOf(AvklaringKafkaObservatør(rapid))),
                 kildeRepository,
                 prosessregister,
             ),
         )
-    private val meldekortRepository = MeldekortRepositoryPostgres(dbTestContext.dataSource)
+    private val meldekortRepository = MeldekortRepositoryPostgres(dbTestContext.dbSession)
     private val ventendeMeldekort = VentendeMeldekortDings(meldekortRepository)
     private val hendelseMediator =
         HendelseMediator(
-            postgres = UtboksLagerPostgres(dbTestContext.dataSource),
+            postgres = UtboksLagerPostgres(dbTestContext.dbSession),
             personRepository = personRepository,
             meldekortRepository = meldekortRepository,
             behovMediator = BehovMediator(),
@@ -77,10 +77,10 @@ internal class SimulertDagpengerSystem(
             listOf(ventendeMeldekort),
         )
 
-    private val postgresMeldingRepository = PostgresMeldingRepository(dbTestContext.dataSource)
+    private val postgresMeldingRepository = PostgresMeldingRepository(dbTestContext.dbSession)
 
-    private val behovssporer = Behovssporer(dbTestContext.dataSource)
-    private val apiRepositoryPostgres = ApiRepositoryPostgres(dbTestContext.dataSource, postgresMeldingRepository, behovssporer)
+    private val behovssporer = Behovssporer(dbTestContext.dbSession)
+    private val apiRepositoryPostgres = ApiRepositoryPostgres(dbTestContext.dbSession, postgresMeldingRepository, behovssporer)
     val auditlogg = TestAuditlogg()
 
     private val regelverk: List<RegelverkRegistrering> = listOf(DagpengerRegistrering(), FerietilleggRegistrering())
@@ -219,7 +219,7 @@ internal class SimulertDagpengerSystem(
     }
 
     val meldekortkø =
-        MeldekortBehandlingskø(dbTestContext.dataSource, personRepository, meldekortRepository, TestRapidMessageContext(rapid))
+        MeldekortBehandlingskø(dbTestContext.dbSession, personRepository, meldekortRepository, TestRapidMessageContext(rapid))
 
     fun meldekortBatch(avklar: Boolean = false) {
         val påbegynteMeldekort = meldekortkø.sendMeldekortTilBehandling()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
@@ -10,7 +10,7 @@ import io.ktor.server.application.Application
 import io.mockk.mockk
 import no.nav.dagpenger.behandling.api.models.BehandlingsresultatDTO
 import no.nav.dagpenger.behandling.db.DBTestContext
-import no.nav.dagpenger.behandling.db.Postgres
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.helpers.scenario.assertions.BehandlingsresultatAssertions
 import no.nav.dagpenger.behandling.mediator.BehovMediator
 import no.nav.dagpenger.behandling.mediator.Behovssporer
@@ -160,8 +160,8 @@ internal class SimulertDagpengerSystem(
         val ordinær: Boolean = false,
         var verneplikt: Boolean = false,
     ) {
-        inline fun test(block: SimulertDagpengerSystem.() -> Unit) {
-            Postgres.withMigratedDb {
+        inline fun test(crossinline block: SimulertDagpengerSystem.() -> Unit) {
+            withMigratedDb {
                 val test = SimulertDagpengerSystem(this, this@ScenarioOptions)
                 test.opprettPerson(ident)
                 test.block()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/db/DatabaseSessionTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/db/DatabaseSessionTest.kt
@@ -1,20 +1,19 @@
-package no.nav.dagpenger.behandling.mediator.repository
+package no.nav.dagpenger.behandling.mediator.db
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.mediator.repository.DbMetrics
 import org.junit.jupiter.api.Test
-import javax.sql.DataSource
 
-class PostgresUnitOfWorkTest {
+class DatabaseSessionTest {
     @Test
     fun `rydder opp etter seg og lager ikke connetion leaks`() {
         withMigratedDb {
             repeat(100) {
                 runCatching {
-                    PostgresUnitOfWork.transaction(dataSource) {
+                    dbSession.transaction {
                         session.run(queryOf("SELECT 1lasdf!").map { it.int(1) }.asSingle)
                     }
                 }.onFailure { println(it.message) }.onSuccess { throw Error("nien") }
@@ -24,17 +23,17 @@ class PostgresUnitOfWorkTest {
 
     @Test
     fun `skal commite når ingen exceptions`() {
-        transaksjonstest { dataSource ->
+        transaksjonstest { dbSession ->
             val commitCountFørTest = DbMetrics.commitCounter.longValue
 
-            PostgresUnitOfWork.transaction(dataSource) {
+            dbSession.transaction {
                 DbMetrics.activeTransactions.get() shouldBe 1.0
                 session.run(queryOf("update counter set value = 42 where id = 1").asUpdate) shouldBe 1
             }
 
             DbMetrics.activeTransactions.get() shouldBe 0.0
             (DbMetrics.commitCounter.longValue - commitCountFørTest) shouldBe 1
-            sessionOf(dataSource).use { session ->
+            dbSession.session { session ->
                 session.run(queryOf("select value from counter where id = 1").map { it.int(1) }.asSingle) shouldBe 42
             }
         }
@@ -42,12 +41,12 @@ class PostgresUnitOfWorkTest {
 
     @Test
     fun `skal rollbacke ved feil`() {
-        transaksjonstest { dataSource ->
+        transaksjonstest { dbSession ->
             val commitCountFørTest = DbMetrics.commitCounter.longValue
             val rollbackCountFørTest = DbMetrics.rollbackCounter.longValue
 
             shouldThrow<IllegalStateException> {
-                PostgresUnitOfWork.transaction(dataSource) {
+                dbSession.transaction {
                     session.run(queryOf("update counter set value = 42 where id = 1").asUpdate) shouldBe 1
                     error("rollback")
                 }
@@ -55,19 +54,19 @@ class PostgresUnitOfWorkTest {
 
             (DbMetrics.commitCounter.longValue - commitCountFørTest) shouldBe 0
             (DbMetrics.rollbackCounter.longValue - rollbackCountFørTest) shouldBe 1
-            sessionOf(dataSource).use { session ->
+            dbSession.session { session ->
                 session.run(queryOf("select value from counter where id = 1").map { it.int(1) }.asSingle) shouldBe 1
             }
         }
     }
 }
 
-private fun transaksjonstest(testblokk: (DataSource) -> Unit) {
+private fun transaksjonstest(testblokk: (DatabaseSession) -> Unit) {
     withMigratedDb {
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.run(queryOf("create table counter (id int primary key, value int)").asExecute)
             session.run(queryOf("insert into counter values (1, 1)").asExecute)
         }
-        testblokk(dataSource)
+        testblokk(dbSession)
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/db/DatabaseSessionTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/db/DatabaseSessionTest.kt
@@ -3,7 +3,7 @@ package no.nav.dagpenger.behandling.mediator.db
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotliquery.queryOf
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.mediator.repository.DbMetrics
 import org.junit.jupiter.api.Test
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/meldekort/MeldekortBehandlingskøTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/meldekort/MeldekortBehandlingskøTest.kt
@@ -25,13 +25,13 @@ class MeldekortBehandlingskøTest {
     @Test
     fun `tester kø`() {
         withMigratedDb {
-            val meldekortRepository = MeldekortRepositoryPostgres(dataSource)
+            val meldekortRepository = MeldekortRepositoryPostgres(dbSession)
             // Bruker en eksplisitt virkedag (mandag) for å unngå flaky tester på helger/helligdager
             val kjøringsdato = LocalDate.of(2024, 1, 29)
-            val meldekort = MeldekortBehandlingskø(dataSource, personRepository, meldekortRepository, rapid)
+            val meldekort = MeldekortBehandlingskø(dbSession, personRepository, meldekortRepository, rapid)
             lagPerson(1.januar(2024))
 
-            val person = meldekortRepository.generatorFor(dataSource, ident, 1.januar(2024))
+            val person = meldekortRepository.generatorFor(dbSession, ident, 1.januar(2024))
             person.lagMeldekort(2)
 
             // Første meldekort behandles

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/meldekort/MeldekortBehandlingskøTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/meldekort/MeldekortBehandlingskøTest.kt
@@ -4,7 +4,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.januar
 import no.nav.dagpenger.behandling.mediator.repository.MeldekortRepositoryPostgres
 import no.nav.dagpenger.behandling.mediator.repository.Meldekortgenerator.Companion.generatorFor

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/melding/PostgresMeldingRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/melding/PostgresMeldingRepositoryTest.kt
@@ -12,7 +12,7 @@ internal class PostgresMeldingRepositoryTest {
         val melding = ApiMelding(ident)
 
         Postgres.withMigratedDb {
-            val postgresHendelseRepository = PostgresMeldingRepository(dataSource)
+            val postgresHendelseRepository = PostgresMeldingRepository(dbSession)
             postgresHendelseRepository.lagreMelding(
                 melding = melding,
                 ident = ident,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/melding/PostgresMeldingRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/melding/PostgresMeldingRepositoryTest.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.behandling.mediator.melding
 
 import io.kotest.matchers.equals.shouldBeEqual
-import no.nav.dagpenger.behandling.db.Postgres
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.mediator.repository.ApiMelding
 import kotlin.test.Test
 
@@ -11,7 +11,7 @@ internal class PostgresMeldingRepositoryTest {
         val ident = "12345678910"
         val melding = ApiMelding(ident)
 
-        Postgres.withMigratedDb {
+        withMigratedDb {
             val postgresHendelseRepository = PostgresMeldingRepository(dbSession)
             postgresHendelseRepository.lagreMelding(
                 melding = melding,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/mottak/ArenaOppgaveMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/mottak/ArenaOppgaveMottakTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.spyk
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.mediator.asUUID
 import no.nav.dagpenger.behandling.modell.Behandling
 import org.intellij.lang.annotations.Language

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/mottak/ArenaOppgaveMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/mottak/ArenaOppgaveMottakTest.kt
@@ -142,7 +142,7 @@ class ArenaOppgaveMottakTest {
 
     private fun arenaOppgavemottakTest(block: Arenatest.() -> Unit) {
         withMigratedDb {
-            val sakRepository = spyk(SakRepositoryPostgres(dataSource))
+            val sakRepository = spyk(SakRepositoryPostgres(dbSession))
 
             val rapid =
                 TestRapid().apply {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/ApiRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/ApiRepositoryPostgresTest.kt
@@ -6,23 +6,22 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.behandling.mediator.Behovssporer
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType
 import org.junit.jupiter.api.Test
 import java.util.UUID
-import javax.sql.DataSource
 
 class ApiRepositoryPostgresTest {
     @Test
     fun `kan vente på endringer i tilstand`() {
         withMigratedDb {
-            val behandling = Behandling(dataSource, UUID.randomUUID())
+            val behandling = Behandling(dbSession, UUID.randomUUID())
             behandling.endreTilstand(TilstandType.ForslagTilVedtak)
 
-            val behovssporer = Behovssporer(dataSource)
-            val repo = ApiRepositoryPostgres(dataSource, io.mockk.mockk(), behovssporer)
+            val behovssporer = Behovssporer(dbSession)
+            val repo = ApiRepositoryPostgres(dbSession, io.mockk.mockk(), behovssporer)
 
             runBlocking {
                 repo.endreOpplysning(
@@ -45,11 +44,11 @@ class ApiRepositoryPostgresTest {
     }
 
     private class Behandling(
-        val dataSource: DataSource,
+        val dbSession: DatabaseSession,
         val id: UUID,
     ) {
         fun endreTilstand(tilstand: TilstandType) =
-            sessionOf(dataSource).use {
+            dbSession.session {
                 it.run(
                     queryOf(
                         //language=PostgreSQL

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/ApiRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/ApiRepositoryPostgresTest.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotliquery.queryOf
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.mediator.Behovssporer
 import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgresTest.kt
@@ -120,15 +120,15 @@ class AvklaringRepositoryPostgresTest {
 
     private fun avklaringTest(block: Avklaringtest.() -> Unit) {
         withMigratedDb {
-            val kildeRepository = KildeRepository(dataSource)
-            val repository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
+            val kildeRepository = KildeRepository(dbSession)
+            val repository = AvklaringRepositoryPostgres(dbSession, kildeRepository)
             val prosessregister =
                 Prosessregister().also {
                     TestBehandlinger.registrerTestProsesser(it)
                 }
             val behandlingRepository =
-                BehandlingRepositoryPostgres(dataSource, opplysningerRepository(dataSource), repository, kildeRepository, prosessregister)
-            val personRepository = PersonRepositoryPostgres(dataSource, behandlingRepository)
+                BehandlingRepositoryPostgres(dbSession, opplysningerRepository(dbSession), repository, kildeRepository, prosessregister)
+            val personRepository = PersonRepositoryPostgres(dbSession, behandlingRepository)
             block(Avklaringtest(repository, behandlingRepository, personRepository))
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/AvklaringRepositoryPostgresTest.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.avklaring.Avklaringer
 import no.nav.dagpenger.behandling.TestOpplysningstyper.opplysningerRepository
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.modell.Ident
 import no.nav.dagpenger.behandling.modell.Person
 import no.nav.dagpenger.behandling.modell.hendelser.AvklaringKvittertHendelse

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresPerformanceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresPerformanceTest.kt
@@ -88,7 +88,7 @@ class BehandlingRepositoryPostgresPerformanceTest {
         behandlingRepositoryPostgres: BehandlingRepositoryPostgres,
         behandlinger: List<Behandling>,
     ) {
-        val personRepositoryPostgres = PersonRepositoryPostgres(dataSource, behandlingRepositoryPostgres)
+        val personRepositoryPostgres = PersonRepositoryPostgres(dbSession, behandlingRepositoryPostgres)
 
         val kjeder =
             behandlinger
@@ -106,16 +106,16 @@ class BehandlingRepositoryPostgresPerformanceTest {
         val antallOpplysningerPerBehandling = 100
 
         withMigratedDb {
-            val kildeRepository = KildeRepository(dataSource)
-            val avklaringRepository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
-            val opplysningerRepository = OpplysningerRepositoryPostgres(dataSource, kildeRepository)
+            val kildeRepository = KildeRepository(dbSession)
+            val avklaringRepository = AvklaringRepositoryPostgres(dbSession, kildeRepository)
+            val opplysningerRepository = OpplysningerRepositoryPostgres(dbSession, kildeRepository)
             // Registrer forretningsprosesser og opplysningstyper
             val prosessregister = Prosessregister()
             DagpengerRegistrering().registrerProsesser(prosessregister)
             FerietilleggRegistrering().registrerProsesser(prosessregister)
             opplysningerRepository.lagreOpplysningstyper(opplysningstyper.toSet())
             val behandlingRepository =
-                BehandlingRepositoryPostgres(dataSource, opplysningerRepository, avklaringRepository, kildeRepository, prosessregister)
+                BehandlingRepositoryPostgres(dbSession, opplysningerRepository, avklaringRepository, kildeRepository, prosessregister)
 
             // Lag kjede av behandlinger, hver med mange opplysninger
             var forrigeBehandling: Behandling? = null
@@ -206,16 +206,16 @@ class BehandlingRepositoryPostgresPerformanceTest {
         val antallOpplysningerPerBehandling = 50
 
         withMigratedDb {
-            val kildeRepository = KildeRepository(dataSource)
-            val avklaringRepository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
-            val opplysningerRepository = OpplysningerRepositoryPostgres(dataSource, kildeRepository)
+            val kildeRepository = KildeRepository(dbSession)
+            val avklaringRepository = AvklaringRepositoryPostgres(dbSession, kildeRepository)
+            val opplysningerRepository = OpplysningerRepositoryPostgres(dbSession, kildeRepository)
             // Registrer forretningsprosesser og opplysningstyper
             val prosessregister = Prosessregister()
             DagpengerRegistrering().registrerProsesser(prosessregister)
             FerietilleggRegistrering().registrerProsesser(prosessregister)
             opplysningerRepository.lagreOpplysningstyper(opplysningstyper.toSet())
             val behandlingRepository =
-                BehandlingRepositoryPostgres(dataSource, opplysningerRepository, avklaringRepository, kildeRepository, prosessregister)
+                BehandlingRepositoryPostgres(dbSession, opplysningerRepository, avklaringRepository, kildeRepository, prosessregister)
 
             // Lag en rot-behandling som alle kjeder baserer seg på
             val rotSøknadId = UUIDv7.ny()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresPerformanceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresPerformanceTest.kt
@@ -3,7 +3,7 @@ package no.nav.dagpenger.behandling.mediator.repository
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.behandling.db.DBTestContext
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.modell.Behandling
 import no.nav.dagpenger.behandling.modell.Ident
 import no.nav.dagpenger.behandling.modell.Person

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresTest.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.dagpenger.avklaring.Avklaring
 import no.nav.dagpenger.behandling.TestOpplysningstyper.opplysningerRepository
 import no.nav.dagpenger.behandling.db.DBTestContext
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.modell.Behandling
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType.Ferdig
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType.UnderBehandling

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/BehandlingRepositoryPostgresTest.kt
@@ -92,16 +92,16 @@ class BehandlingRepositoryPostgresTest {
     @Test
     fun `lagre og hente en kjede med grener fra postgres`() {
         withMigratedDb {
-            val kildeRepository = KildeRepository(dataSource)
-            val opplysningerRepository = OpplysningerRepositoryPostgres(dataSource, kildeRepository)
+            val kildeRepository = KildeRepository(dbSession)
+            val opplysningerRepository = OpplysningerRepositoryPostgres(dbSession, kildeRepository)
             // Registrer forretningsprosesser og opplysningstyper
             val prosessregister = Prosessregister()
             TestBehandlinger.registrerTestProsesser(prosessregister)
             opplysningerRepository.lagreOpplysningstyper(opplysningstyper)
 
-            val avklaringRepository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
+            val avklaringRepository = AvklaringRepositoryPostgres(dbSession, kildeRepository)
             val behandlingRepositoryPostgres =
-                BehandlingRepositoryPostgres(dataSource, opplysningerRepository, avklaringRepository, kildeRepository, prosessregister)
+                BehandlingRepositoryPostgres(dbSession, opplysningerRepository, avklaringRepository, kildeRepository, prosessregister)
 
             val b1 = nyBehandling(null, Ferdig, Opplysninger.med(datoOpplysning))
             val b2 = nyBehandling(b1, Ferdig, Opplysninger.med(opplysning2))
@@ -133,16 +133,16 @@ class BehandlingRepositoryPostgresTest {
     @Test
     fun `flytter en eldre behandling til å peke på en nyere`() {
         withMigratedDb {
-            val kildeRepository = KildeRepository(dataSource)
-            val opplysningerRepository = OpplysningerRepositoryPostgres(dataSource, kildeRepository)
+            val kildeRepository = KildeRepository(dbSession)
+            val opplysningerRepository = OpplysningerRepositoryPostgres(dbSession, kildeRepository)
             // Registrer forretningsprosesser og opplysningstyper
             val prosessregister = Prosessregister()
             TestBehandlinger.registrerTestProsesser(prosessregister)
             opplysningerRepository.lagreOpplysningstyper(opplysningstyper)
 
-            val avklaringRepository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
+            val avklaringRepository = AvklaringRepositoryPostgres(dbSession, kildeRepository)
             val behandlingRepositoryPostgres =
-                BehandlingRepositoryPostgres(dataSource, opplysningerRepository, avklaringRepository, kildeRepository, prosessregister)
+                BehandlingRepositoryPostgres(dbSession, opplysningerRepository, avklaringRepository, kildeRepository, prosessregister)
 
             val b1 = nyBehandling(null, Ferdig, Opplysninger.med(datoOpplysning))
             val b2 = nyBehandling(b1, UnderBehandling, Opplysninger.med(opplysning2))
@@ -173,18 +173,18 @@ class BehandlingRepositoryPostgresTest {
     @Test
     fun `lagre og hent behandling fra postgres`() {
         withMigratedDb {
-            val kildeRepository = KildeRepository(dataSource)
-            val opplysningerRepository = OpplysningerRepositoryPostgres(dataSource, kildeRepository)
+            val kildeRepository = KildeRepository(dbSession)
+            val opplysningerRepository = OpplysningerRepositoryPostgres(dbSession, kildeRepository)
             // Registrer forretningsprosesser og opplysningstyper
             val prosessregister = Prosessregister()
             TestBehandlinger.registrerTestProsesser(prosessregister)
             opplysningerRepository.lagreOpplysningstyper(opplysningstyper)
 
-            val avklaringRepository = AvklaringRepositoryPostgres(dataSource, kildeRepository)
+            val avklaringRepository = AvklaringRepositoryPostgres(dbSession, kildeRepository)
             val behandlingRepositoryPostgres =
                 BehandlingRepositoryPostgres(
-                    dataSource = dataSource,
-                    opplysningRepository = opplysningerRepository(dataSource),
+                    dbSession = dbSession,
+                    opplysningRepository = opplysningerRepository(dbSession),
                     avklaringRepository = avklaringRepository,
                     kildeRepository = kildeRepository,
                     prosessregister = prosessregister,
@@ -229,7 +229,7 @@ class BehandlingRepositoryPostgresTest {
         behandlingRepositoryPostgres: BehandlingRepositoryPostgres,
         behandlinger: List<Behandling>,
     ) {
-        val personRepositoryPostgres = PersonRepositoryPostgres(dataSource, behandlingRepositoryPostgres)
+        val personRepositoryPostgres = PersonRepositoryPostgres(dbSession, behandlingRepositoryPostgres)
 
         val kjeder =
             behandlinger

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/KildeRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/KildeRepositoryTest.kt
@@ -4,7 +4,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.mockk
 import kotliquery.queryOf
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.melding.PostgresMeldingRepository
 import no.nav.dagpenger.opplysning.Saksbehandler

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/KildeRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/KildeRepositoryTest.kt
@@ -4,14 +4,13 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.mockk
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.melding.PostgresMeldingRepository
 import no.nav.dagpenger.opplysning.Saksbehandler
 import no.nav.dagpenger.opplysning.Saksbehandlerkilde
 import org.junit.jupiter.api.Test
 import java.util.UUID
-import javax.sql.DataSource
 
 class KildeRepositoryTest {
     @Test
@@ -30,23 +29,22 @@ class KildeRepositoryTest {
     fun `Lagre kilde uten begrunnelse`() {
         kildeTest {
             // Lagre en tom begrunnelse uten begrunnelse_sist_endret
-            sessionOf(dataSource)
-                .use { session ->
-                    session.run(
-                        queryOf(
-                            //language=PostgreSQL
-                            """
-                            UPDATE kilde_saksbehandler 
-                            SET begrunnelse = :begrunnelse 
-                            WHERE kilde_id = :kildeId
-                            """.trimIndent(),
-                            mapOf(
-                                "kildeId" to kilde.id,
-                                "begrunnelse" to "",
-                            ),
-                        ).asUpdate,
-                    )
-                }
+            dbSession.session { session ->
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        """
+                        UPDATE kilde_saksbehandler 
+                        SET begrunnelse = :begrunnelse 
+                        WHERE kilde_id = :kildeId
+                        """.trimIndent(),
+                        mapOf(
+                            "kildeId" to kilde.id,
+                            "begrunnelse" to "",
+                        ),
+                    ).asUpdate,
+                )
+            }
 
             with(kildeRepository.hentKilde(kilde.id)) {
                 shouldBeInstanceOf<Saksbehandlerkilde>()
@@ -59,7 +57,7 @@ class KildeRepositoryTest {
     private fun kildeTest(block: Kildetest.() -> Unit) {
         withMigratedDb {
             val meldingsreferanseId = UUID.randomUUID()
-            PostgresMeldingRepository(dataSource).also {
+            PostgresMeldingRepository(dbSession).also {
                 it.lagreMelding(
                     mockk(),
                     "123456789",
@@ -68,19 +66,19 @@ class KildeRepositoryTest {
                 )
             }
 
-            val kildeRepository = KildeRepository(dataSource)
+            val kildeRepository = KildeRepository(dbSession)
             val kilde = Saksbehandlerkilde(meldingsreferanseId, Saksbehandler("EIF2025"))
             // trenger en session her fordi det brukes til å lagre ting
-            sessionOf(dataSource).use {
+            dbSession.session {
                 kildeRepository.lagreKilde(kilde, it)
             }
-            block(Kildetest(kildeRepository, kilde, dataSource))
+            block(Kildetest(kildeRepository, kilde, dbSession))
         }
     }
 
     private data class Kildetest(
         val kildeRepository: KildeRepository,
         val kilde: Saksbehandlerkilde,
-        val dataSource: DataSource,
+        val dbSession: DatabaseSession,
     )
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/MeldekortRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/MeldekortRepositoryPostgresTest.kt
@@ -7,7 +7,6 @@ import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.behandling.db.DBTestContext
 import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
 import no.nav.dagpenger.behandling.januar
@@ -31,7 +30,7 @@ class MeldekortRepositoryPostgresTest {
     @Test
     fun `lagre og hente meldekort`() {
         withMigratedDb {
-            val meldekortRepository = MeldekortRepositoryPostgres(dataSource)
+            val meldekortRepository = MeldekortRepositoryPostgres(dbSession)
             val ident = "12345678910"
             val start = LocalDate.now()
             val dager =
@@ -134,7 +133,7 @@ class MeldekortRepositoryPostgresTest {
     @Test
     fun `kan lagre meldekort uten aktivitet på alle dager`() {
         withMigratedDb {
-            val meldekortRepository = MeldekortRepositoryPostgres(dataSource)
+            val meldekortRepository = MeldekortRepositoryPostgres(dbSession)
             val ident = "12345678910"
             val start = LocalDate.now()
             val dager =
@@ -186,7 +185,7 @@ class MeldekortRepositoryPostgresTest {
         ident: String,
         meldekortInnsendtHendelse: MeldekortInnsendtHendelse,
     ) {
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -199,7 +198,7 @@ class MeldekortRepositoryPostgresTest {
                 ).asUpdate,
             )
         }
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -229,13 +228,13 @@ class MeldekortRepositoryPostgresTest {
     @Test
     fun hentUbehandledeMeldekort() {
         withMigratedDb {
-            val repo = MeldekortRepositoryPostgres(dataSource)
+            val repo = MeldekortRepositoryPostgres(dbSession)
             val meldingGenerator = Meldekortgenerator.meldekortIdGenerator
             // Bruker en eksplisitt virkedag for å unngå flaky tester på helger/helligdager
             val kjøringsdato = LocalDate.of(2024, 7, 1)
 
-            val person1 = repo.generatorFor(dataSource, "111111111", 1.januar(2024), meldingGenerator)
-            val person2 = repo.generatorFor(dataSource, "222222222", 1.januar(2024), meldingGenerator)
+            val person1 = repo.generatorFor(dbSession, "111111111", 1.januar(2024), meldingGenerator)
+            val person2 = repo.generatorFor(dbSession, "222222222", 1.januar(2024), meldingGenerator)
 
             person1.lagMeldekort(10)
             person2.lagMeldekort(10)
@@ -286,10 +285,10 @@ class MeldekortRepositoryPostgresTest {
     @Test
     fun hentKorrigeringer() {
         withMigratedDb {
-            val repo = MeldekortRepositoryPostgres(dataSource)
+            val repo = MeldekortRepositoryPostgres(dbSession)
             val meldingGenerator = Meldekortgenerator.meldekortIdGenerator
 
-            val person1 = repo.generatorFor(dataSource, "111111111", 1.januar(2024), meldingGenerator)
+            val person1 = repo.generatorFor(dbSession, "111111111", 1.januar(2024), meldingGenerator)
 
             person1.lagMeldekort(3)
 
@@ -328,10 +327,10 @@ class MeldekortRepositoryPostgresTest {
     @Test
     fun `plukker ikke meldekort som er sendt inn før meldedag`() {
         withMigratedDb {
-            val repo = MeldekortRepositoryPostgres(dataSource)
+            val repo = MeldekortRepositoryPostgres(dbSession)
             val meldingGenerator = Meldekortgenerator.meldekortIdGenerator
 
-            val person1 = repo.generatorFor(dataSource, "111111111", 1.januar(2018), meldingGenerator)
+            val person1 = repo.generatorFor(dbSession, "111111111", 1.januar(2018), meldingGenerator)
             person1.lagMeldekort(5)
 
             repo.hentMeldekortkø(11.januar(2018)).behandlingsklare shouldHaveSize 0

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/MeldekortRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/MeldekortRepositoryPostgresTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotliquery.queryOf
 import no.nav.dagpenger.behandling.db.DBTestContext
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.januar
 import no.nav.dagpenger.behandling.mediator.repository.Meldekortgenerator.Companion.generatorFor
 import no.nav.dagpenger.behandling.modell.hendelser.AktivitetType

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/Meldekortgenerator.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/Meldekortgenerator.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.behandling.mediator.repository
 
 import kotliquery.queryOf
-import kotliquery.sessionOf
+import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.modell.hendelser.Dag
 import no.nav.dagpenger.behandling.modell.hendelser.Meldekort
 import no.nav.dagpenger.behandling.modell.hendelser.MeldekortId
@@ -12,11 +12,10 @@ import org.postgresql.util.PGobject
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
-import javax.sql.DataSource
 
 class Meldekortgenerator private constructor(
     private val repository: MeldekortRepository,
-    private val dataSource: DataSource,
+    private val dbSession: DatabaseSession,
     val ident: String,
     private val eksternMeldekortId: Iterator<Long>,
     startdato: LocalDate = LocalDate.now(),
@@ -94,7 +93,7 @@ class Meldekortgenerator private constructor(
                 meldingsreferanseId = meldekort.meldingsreferanseId,
                 meldekort = meldekort,
             )
-        sessionOf(dataSource).use { session ->
+        dbSession.session { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -145,7 +144,7 @@ class Meldekortgenerator private constructor(
 
     companion object {
         fun MeldekortRepository.generatorFor(
-            dataSource: DataSource,
+            dataSource: DatabaseSession,
             ident: String,
             startdato: LocalDate,
             generator: Iterator<Long> = meldekortIdGenerator,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgresTest.kt
@@ -24,7 +24,7 @@ import no.nav.dagpenger.behandling.TestOpplysningstyper.periode
 import no.nav.dagpenger.behandling.TestOpplysningstyper.tekst
 import no.nav.dagpenger.behandling.TestOpplysningstyper.utledetOpplysningstype
 import no.nav.dagpenger.behandling.april
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.juli
 import no.nav.dagpenger.behandling.mai
 import no.nav.dagpenger.behandling.mediator.objectMapper

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgresTest.kt
@@ -8,7 +8,6 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotliquery.queryOf
-import kotliquery.sessionOf
 import no.nav.dagpenger.behandling.TestOpplysningstyper.barn
 import no.nav.dagpenger.behandling.TestOpplysningstyper.baseOpplysningstype
 import no.nav.dagpenger.behandling.TestOpplysningstyper.beløpA
@@ -65,7 +64,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `lagrer enkle opplysninger`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
             val heltallFaktum = Faktum(heltall, 10)
             val kildeA = Saksbehandlerkilde(UUIDv7.ny(), Saksbehandler("foo"))
             val boolskFaktum = Faktum(boolsk, true, kilde = kildeA)
@@ -114,7 +113,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `lagre opplysningens gyldighetsperiode`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
             val gyldighetsperiode1 = Gyldighetsperiode(LocalDate.now(), LocalDate.now().plusDays(14))
             val faktum1 = Faktum(heltall, 10, gyldighetsperiode1)
             val opplysninger = Opplysninger.med(faktum1)
@@ -130,7 +129,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `lagrer grenseverdier for dato opplysninger`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
             val kilde = Saksbehandlerkilde(UUIDv7.ny(), Saksbehandler("foo"))
             val maksDatoFaktum = Faktum(maksdato, LocalDate.MAX, kilde = kilde)
             val minDatoFaktum = Faktum(mindato, LocalDate.MIN, kilde = kilde)
@@ -150,7 +149,7 @@ class OpplysningerRepositoryPostgresTest {
     @Disabled("Modellen støtter ikke å bruke opplysninger med samme navn og ulik type")
     fun `lagrer opplysninger med samme navn og ulik type`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
             val opplysningstype = Opplysningstype.ulid(Opplysningstype.Id(UUIDv7.ny(), ULID), "Ulid")
             val opplysningstype1 = Opplysningstype.boolsk(Opplysningstype.Id(UUIDv7.ny(), Boolsk), "Ulid")
 
@@ -172,7 +171,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `lagrer opplysninger med utledning`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
 
             val baseOpplysning = Faktum(baseOpplysningstype, LocalDate.now())
 
@@ -213,7 +212,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `Klarer å lagre store mengder opplysninger effektivt`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
             val fakta =
                 (1..50000).map {
                     val fomTom = LocalDate.now().minusDays(it.toLong())
@@ -232,7 +231,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `skriver over erstattet opplysning i samme Opplysninger`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
             val opplysning = Faktum(heltall, 10)
             val opplysningErstattet = Faktum(heltall, 20)
             val opplysninger = Opplysninger.med(opplysning)
@@ -253,7 +252,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `kan erstatte opplysning i tidligere Opplysninger`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
 
             // Lag opplysninger med opprinnelig opplysning
             val opplysning = Faktum(heltall, 10)
@@ -296,7 +295,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `lagrer opplysninger med utledning fra tidligere opplysninger`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
 
             val baseOpplysning = Faktum(baseOpplysningstype, LocalDate.now())
 
@@ -351,7 +350,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `lagrer penger som BigDecimal med riktig presisjon`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
 
             val verdi = "10.00000000000000000006"
             val verdi1 = BigDecimal(verdi)
@@ -380,7 +379,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `kan lagre inntekt`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
             val inntektV1: no.nav.dagpenger.inntekt.v1.Inntekt =
                 objectMapper.readValue(
                     this.javaClass.getResourceAsStream("/test-data/inntekt.json"),
@@ -407,7 +406,7 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `Kan hente BarnListe av gammel versjon for bakoverkompatibilitet`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
             val barn =
                 Faktum(
                     barn,
@@ -421,7 +420,7 @@ class OpplysningerRepositoryPostgresTest {
             repo.lagreOpplysninger(opplysninger)
 
             // Jukser litt å legger det gamle formatet rett i databasen for å simulere en gammel lagret opplysning (uten søknadsbarnId)
-            sessionOf(dataSource).use { session ->
+            dbSession.session { session ->
                 session.run(
                     queryOf(
                         //language=PostgreSQL
@@ -470,8 +469,8 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `kan fjerne opplysninger`() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
-            val vaktmesterRepo = VaktmesterPostgresRepo(dataSource)
+            val repo = opplysningerRepository(dbSession)
+            val vaktmesterRepo = VaktmesterPostgresRepo(dbSession)
             val heltallFaktum = Faktum(heltall, 10)
             val heltallFaktum2 = Faktum(heltall, 20)
             val opplysninger = Opplysninger.med(heltallFaktum)
@@ -488,8 +487,8 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `ikke slette mer enn vi skal fra tidligere opplysninger `() {
         withMigratedDb {
-            val repo = opplysningerRepository(dataSource)
-            val vaktmesterRepo = VaktmesterPostgresRepo(dataSource)
+            val repo = opplysningerRepository(dbSession)
+            val vaktmesterRepo = VaktmesterPostgresRepo(dbSession)
 
             // Gammel behandling
             val opprinneligDato = LocalDate.now()
@@ -552,8 +551,8 @@ class OpplysningerRepositoryPostgresTest {
             val d = Opplysningstype.boolsk(Opplysningstype.Id(UUIDv7.ny(), Boolsk), "D")
             val e = Opplysningstype.boolsk(Opplysningstype.Id(UUIDv7.ny(), Boolsk), "E")
             val f = Opplysningstype.boolsk(Opplysningstype.Id(UUIDv7.ny(), Boolsk), "F")
-            val repo = opplysningerRepository(dataSource)
-            val vaktmesterRepo = VaktmesterPostgresRepo(dataSource)
+            val repo = opplysningerRepository(dbSession)
+            val vaktmesterRepo = VaktmesterPostgresRepo(dbSession)
 
             val regelsett1 =
                 vilkår("vilkår en") {
@@ -598,14 +597,14 @@ class OpplysningerRepositoryPostgresTest {
     @Test
     fun `Sletter flere sett med opplysninger`() {
         withMigratedDb {
-            val vaktmesterRepo = VaktmesterPostgresRepo(dataSource)
+            val vaktmesterRepo = VaktmesterPostgresRepo(dbSession)
 
             val a = Opplysningstype.boolsk(Opplysningstype.Id(UUIDv7.ny(), Boolsk), "A")
             val b = Opplysningstype.boolsk(Opplysningstype.Id(UUIDv7.ny(), Boolsk), "B")
             val c = Opplysningstype.boolsk(Opplysningstype.Id(UUIDv7.ny(), Boolsk), "C")
             val d = Opplysningstype.boolsk(Opplysningstype.Id(UUIDv7.ny(), Boolsk), "D")
 
-            val repo = opplysningerRepository(dataSource)
+            val repo = opplysningerRepository(dbSession)
 
             val regelsett =
                 vilkår("vilkår") {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/PersonRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/PersonRepositoryPostgresTest.kt
@@ -96,13 +96,13 @@ class PersonRepositoryPostgresTest {
                 Prosessregister().also {
                     TestBehandlinger.registrerTestProsesser(it)
                 }
-            val kildeRepository = KildeRepository(dataSource)
+            val kildeRepository = KildeRepository(dbSession)
             val personRepositoryPostgres =
                 PersonRepositoryPostgres(
-                    dataSource,
+                    dbSession,
                     BehandlingRepositoryPostgres(
-                        dataSource,
-                        opplysningerRepository(dataSource),
+                        dbSession,
+                        opplysningerRepository(dbSession),
                         mockk(relaxed = true),
                         kildeRepository,
                         prosessregister,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/PersonRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/repository/PersonRepositoryPostgresTest.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import no.nav.dagpenger.behandling.TestOpplysningstyper.heltall
 import no.nav.dagpenger.behandling.TestOpplysningstyper.opplysningerRepository
-import no.nav.dagpenger.behandling.db.Postgres.withMigratedDb
+import no.nav.dagpenger.behandling.db.withMigratedDb
 import no.nav.dagpenger.behandling.mediator.Metrikk.hentPersonTimer
 import no.nav.dagpenger.behandling.modell.Behandling
 import no.nav.dagpenger.behandling.modell.Ident

--- a/mediator/src/test/resources/junit-platform.properties
+++ b/mediator/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=8
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=8


### PR DESCRIPTION
Mulig design for å kjøre databasetester i parallell. 

Scenario-testene kjøres på rundt 23 sekunder samlet. 

Algoritmen er slik:
1. fyrer opp én testcontainer
2. lager en liste av `n` potensielle testsesjoner (med laziness sånn at datasourcen ikke gjør oppkobling med en gang)
3. når en test trenger en db så tar den `1 stk` testsesjon fra listen, eller venter om det ikke er noen ledige
4. når testen er ferdig returneres testsesjonen til listen

Mulig forbedringer:
hvis bottleneck er den konstante Flyway-migreringen så kan vi ha et design hvor vi migrerer/oppretter tabeller én gang, og
heller tømme databasen manuelt med flere  `TRUNCATE ...` statements etter hver test.