### PR TITLE
kan kjøre databasetester i parallell

### DIFF
--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/fastsetting/DagpengenesStørrelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/fastsetting/DagpengenesStørrelse.kt
@@ -113,7 +113,7 @@ object DagpengenesStørrelse {
         beløp(DagsatsEtterSamordningMedBarnetilleggId, "Dagsats med barnetillegg etter samordning og 90 % regel")
     val harSamordnet = boolsk(HarSamordnetId, "Har samordnet")
 
-    val regelsett =
+    val regelsett by lazy {
         fastsettelse(
             folketrygden.hjemmel(4, 12, "Dagpengenes størrelse", "Sats og barnetillegg"),
         ) {
@@ -167,6 +167,7 @@ object DagpengenesStørrelse {
 
             ønsketResultat(ukessats, dagsatsSamordnetUtenforFolketrygden, ukesatsMedBarnetillegg, harSamordnet)
         }
+    }
 
     val BarnetilleggKontroll =
         Kontrollpunkt(BarnMåGodkjennes) {

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/fastsetting/SamordingUtenforFolketrygden.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/fastsetting/SamordingUtenforFolketrygden.kt
@@ -150,7 +150,7 @@ object SamordingUtenforFolketrygden {
             "Dagsats uten barnetillegg samordnet",
         )
 
-    val regelsett =
+    val regelsett by lazy {
         fastsettelse(
             folketrygden.hjemmel(
                 4,
@@ -219,6 +219,7 @@ object SamordingUtenforFolketrygden {
 
             avklaring(YtelserUtenforFolketrygden)
         }
+    }
 
     val YtelserUtenforFolketrygdenKontroll =
         Kontrollpunkt(avklaringkode = Avklaringspunkter.YtelserUtenforFolketrygden) { opplysninger ->

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/fastsetting/Vanligarbeidstid.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/fastsetting/Vanligarbeidstid.kt
@@ -19,7 +19,7 @@ object Vanligarbeidstid {
             "Fastsatt arbeidstid per uke før tap",
             enhet = Enhet.Timer,
         )
-    val regelsett =
+    val regelsett by lazy {
         fastsettelse(
             folketrygden.hjemmel(4, 3, "Fastsettelse av arbeidstid", "Fastsettelse av arbeidstid"),
         ) {
@@ -37,4 +37,5 @@ object Vanligarbeidstid {
                 oppfyllerKravetTilMinsteinntektEllerVerneplikt(it)
             }
         }
+    }
 }

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/vilkår/Samordning.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/vilkår/Samordning.kt
@@ -166,7 +166,7 @@ object Samordning {
     // Fulle dagpenger minus en/flere av reduserte ytelsene man mottar per samme dag (regnestykket)
     // avrundetDagsUtenBarnetillegg - sykepenger - pleiepenger - omsorgspenger - opplæringspenger - uføre - foreldrepenger - svangerskapspenger
 
-    val regelsett =
+    val regelsett by lazy {
         vilkår(
             folketrygden.hjemmel(
                 kapittel = 4,
@@ -243,6 +243,7 @@ object Samordning {
 
             avklaring(Avklaringspunkter.Samordning)
         }
+    }
 
     val SkalSamordnes =
         Kontrollpunkt(Avklaringspunkter.Samordning) {

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/vilkår/TapAvArbeidsinntektOgArbeidstid.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/regelsett/vilkår/TapAvArbeidsinntektOgArbeidstid.kt
@@ -129,7 +129,7 @@ object TapAvArbeidsinntektOgArbeidstid {
     val kravTilTapAvArbeidsinntektOgArbeidstid =
         boolsk(kravTilTapAvArbeidsinntektOgArbeidstidId, "Oppfyller vilkåret om tap av arbeidsinntekt og arbeidstid", synlig = aldriSynlig)
 
-    val regelsett =
+    val regelsett by lazy {
         vilkår(
             folketrygden.hjemmel(4, 3, "Tap av arbeidsinntekt og arbeidstid", "Tap av arbeidsinntekt og arbeidstid"),
         ) {
@@ -180,6 +180,7 @@ object TapAvArbeidsinntektOgArbeidstid {
                 it.har(kravTilTapAvArbeidsinntektOgArbeidstid)
             }
         }
+    }
 
     val beregnetArbeidstidKontroll =
         Kontrollpunkt(avklaringkode = BeregnetArbeidstid) { opplysninger ->

--- a/docs/metrikker.md
+++ b/docs/metrikker.md
@@ -13,7 +13,6 @@ Generert fra `PrometheusRegistry` — legger du til en ny metrikk, oppdateres de
 | `behandling_publiser_aktivitetslogg_sekunder` | histogram | Tid brukt på å hente person med behandlinger | — |
 | `commit_duration_seconds` | histogram | Time spent in actual DB commit | — |
 | `dp_antall_behandlinger` | histogram | Antall behandlinger per person | — |
-| `dp_behandling_aktive_behov` | gauge | Antall aktive (uløste) behov per behovtype og kilde | behov, kilde |
 | `dp_behandling_avbrutt` | counter | Antall avbrutte behandlinger | hendelse_type, aarsak |
 | `dp_behandling_avklaring_levetid_sekunder` | histogram | Tid fra avklaring opprettes til den lukkes, i sekunder | kode |
 | `dp_behandling_avklaring_opprettet` | counter | Avklaringer opprettet i behandling | kode |

--- a/mediator/build.gradle.kts
+++ b/mediator/build.gradle.kts
@@ -54,3 +54,14 @@ dependencies {
 application {
     mainClass.set("no.nav.dagpenger.mediator.AppKt")
 }
+
+tasks.test {
+    val erCI = System.getenv("CI")?.toBoolean() == true
+    val defaultParallelism = if (erCI) 1 else 8
+    val parallelism = System.getenv("TEST_PARALLELISM")?.toInt() ?: defaultParallelism
+    systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+    systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
+    systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
+    systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism", parallelism)
+    systemProperty("junit.jupiter.execution.parallel.config.fixed.max-pool-size", parallelism)
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/TestOpplysningstyper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/TestOpplysningstyper.kt
@@ -46,6 +46,6 @@ internal object TestOpplysningstyper {
 
     fun opplysningerRepository(dataSource: DatabaseSession): OpplysningerRepositoryPostgres =
         OpplysningerRepositoryPostgres(dataSource, KildeRepository(dataSource)).apply {
-            lagreOpplysningstyper(definerteTyper)
+            lagreOpplysningstyper(definerteTyper.toList())
         }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/DatabaseSessionTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/DatabaseSessionTest.kt
@@ -6,7 +6,9 @@ import kotliquery.queryOf
 import no.nav.dagpenger.mediator.db.withMigratedDb
 import no.nav.dagpenger.mediator.repository.DbMetrics
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
 
+@Isolated
 class DatabaseSessionTest {
     @Test
     fun `rydder opp etter seg og lager ikke connetion leaks`() {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/DatabaseSessionTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/DatabaseSessionTest.kt
@@ -3,7 +3,6 @@ package no.nav.dagpenger.mediator.db
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotliquery.queryOf
-import no.nav.dagpenger.mediator.db.withMigratedDb
 import no.nav.dagpenger.mediator.repository.DbMetrics
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Isolated
@@ -64,7 +63,7 @@ class DatabaseSessionTest {
 }
 
 private fun transaksjonstest(testblokk: (DatabaseSession) -> Unit) {
-    withMigratedDb {
+    withIsolatedDb {
         dbSession.session { session ->
             session.run(queryOf("create table counter (id int primary key, value int)").asExecute)
             session.run(queryOf("insert into counter values (1, 1)").asExecute)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/Postgres.kt
@@ -2,9 +2,12 @@ package no.nav.dagpenger.mediator.db
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import no.nav.dagpenger.mediator.db.DatabaseSession
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.flywaydb.core.Flyway
 import org.testcontainers.postgresql.PostgreSQLContainer
+import java.time.Duration
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
 import javax.sql.DataSource
 
 data class DBTestContext(
@@ -31,7 +34,10 @@ data class DBTestContext(
             .size
 }
 
+private val ANTALL_TESTER_I_PARALLELL = System.getProperty("junit.jupiter.execution.parallel.config.fixed.parallelism")?.toInt() ?: 1
+
 internal object Postgres {
+    private val logger = KotlinLogging.logger { }
     private val instance by lazy {
         PostgreSQLContainer("postgres:18.0").apply {
             withReuse(true)
@@ -39,32 +45,68 @@ internal object Postgres {
         }
     }
 
-    private val hikariConfig =
-        HikariConfig().apply {
-            jdbcUrl = instance.jdbcUrl
-            username = instance.username
-            password = instance.password
-        }
-    private val flywayConfig =
-        HikariConfig().apply {
-            hikariConfig.copyStateTo(this)
-        }
+    private val tilgjengeligeTestsesjoner =
+        ArrayBlockingQueue(ANTALL_TESTER_I_PARALLELL, false, opprettInitielleTilkoblinger(ANTALL_TESTER_I_PARALLELL))
 
-    private val dataSource = lazy { HikariDataSource(hikariConfig) }
-    private val flywayDataSource = lazy { HikariDataSource(flywayConfig) }
+    fun withTestContext(block: (DBTestContext) -> Unit) {
+        logger.info { "Tester venter på ledig database..." }
+        val testContext =
+            tilgjengeligeTestsesjoner.poll(Duration.ofSeconds(20).toSeconds(), TimeUnit.SECONDS) ?: error("Fikk ikke tak i databasesesjon!")
+        try {
+            logger.info { "Fikk tak i database..." }
+            block(testContext)
+        } finally {
+            logger.info { "Gir databasen tilbake..." }
+            tilgjengeligeTestsesjoner.offer(testContext)
+        }
+    }
 
-    val testContext = DBTestContext(DatabaseSession(dataSource), flywayDataSource)
+    private fun opprettInitielleTilkoblinger(antall: Int): List<DBTestContext> {
+        logger.info { "Oppretter $antall testdatabaser..." }
+        return (1..antall)
+            .map { "testdb_$it" }
+            .map { databasenavn ->
+                logger.info { "Initialiserer $databasenavn" }
+                logger.info { "oppretter db for $databasenavn" }
+                instance.createConnection("").use { conn ->
+                    conn.createStatement().execute("create database $databasenavn")
+                }
+                logger.info { "oppretter testsesjon for $databasenavn" }
+                createTestSession(instance.withDatabaseName(databasenavn))
+            }
+    }
+
+    private fun createTestSession(instance: PostgreSQLContainer): DBTestContext {
+        val hikariConfig =
+            HikariConfig().apply {
+                jdbcUrl = instance.jdbcUrl
+                username = instance.username
+                password = instance.password
+                maximumPoolSize = 4
+                minimumIdle = 0
+            }
+        val flywayConfig =
+            HikariConfig().apply {
+                hikariConfig.copyStateTo(this)
+            }
+
+        val dataSource = lazy { HikariDataSource(hikariConfig) }
+        val flywayDataSource = lazy { HikariDataSource(flywayConfig) }
+
+        return DBTestContext(DatabaseSession(dataSource), flywayDataSource)
+    }
 }
 
-internal inline fun withMigratedDb(block: DBTestContext.() -> Unit) {
+internal inline fun withMigratedDb(crossinline block: DBTestContext.() -> Unit) {
     withCleanDb {
         runMigration()
         block()
     }
 }
 
-internal inline fun withCleanDb(block: DBTestContext.() -> Unit) {
-    val context = Postgres.testContext
-    context.clean()
-    block(context)
+internal inline fun withCleanDb(crossinline block: DBTestContext.() -> Unit) {
+    Postgres.withTestContext { context ->
+        context.clean()
+        block(context)
+    }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/Postgres.kt
@@ -74,6 +74,8 @@ internal object Postgres {
         }
     }
 
+    private val systemtilkobling = instance.createConnection("")
+
     private val tilgjengeligeTestsesjoner =
         ArrayBlockingQueue(ANTALL_TESTER_I_PARALLELL, false, opprettInitielleTilkoblinger(ANTALL_TESTER_I_PARALLELL))
 
@@ -93,6 +95,17 @@ internal object Postgres {
         }
     }
 
+    fun withIsolatedTestContext(block: (DBTestContext) -> Unit) {
+        val databasenavn = "testdb_isolated_${System.currentTimeMillis()}"
+        val testContext = opprettTilkobling(databasenavn)
+        try {
+            block(testContext)
+        } finally {
+            logger.info { "Sletter midlertidig database" }
+            systemtilkobling.createStatement().execute("drop database $databasenavn with (force)")
+        }
+    }
+
     private fun opprettInitielleTilkoblinger(antall: Int): List<DBTestContext> {
         logger.info { "Oppretter $antall testdatabaser..." }
         return (1..antall)
@@ -103,9 +116,7 @@ internal object Postgres {
     private fun opprettTilkobling(databasenavn: String): DBTestContext {
         logger.info { "Initialiserer $databasenavn" }
         logger.info { "oppretter db for $databasenavn" }
-        instance.createConnection("").use { conn ->
-            conn.createStatement().execute("create database $databasenavn")
-        }
+        systemtilkobling.createStatement().execute("create database $databasenavn")
         logger.info { "oppretter testsesjon for $databasenavn" }
         return createTestSession(databasenavn)
     }
@@ -125,6 +136,12 @@ internal object Postgres {
 
 internal inline fun withMigratedDb(crossinline block: DBTestContext.() -> Unit) {
     Postgres.withTestContext { context ->
+        block(context)
+    }
+}
+
+internal inline fun withIsolatedDb(crossinline block: DBTestContext.() -> Unit) {
+    Postgres.withIsolatedTestContext { context ->
         block(context)
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/Postgres.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/Postgres.kt
@@ -3,35 +3,64 @@ package no.nav.dagpenger.mediator.db
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotliquery.queryOf
 import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.output.MigrateOutput
 import org.testcontainers.postgresql.PostgreSQLContainer
 import java.time.Duration
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.TimeUnit
-import javax.sql.DataSource
 
 data class DBTestContext(
-    val dbSession: DatabaseSession,
-    private val flywayDataSource: Lazy<DataSource>,
+    val baseConfig: HikariConfig,
 ) {
-    private val flyWay by lazy {
-        Flyway
-            .configure()
-            .connectRetries(10)
-            .dataSource(flywayDataSource.value)
-            .cleanDisabled(false)
-            .load()
+    val hikariConfig =
+        HikariConfig().apply {
+            baseConfig.copyStateTo(this)
+            maximumPoolSize = 4
+            minimumIdle = 0
+        }
+
+    val dbSession: DatabaseSession = DatabaseSession(lazy { HikariDataSource(hikariConfig) })
+
+    private val migratedOutput: List<MigrateOutput> by lazy {
+        HikariDataSource(hikariConfig).use { flywayDataSource ->
+            Flyway
+                .configure()
+                .connectRetries(10)
+                .dataSource(flywayDataSource)
+                .load()
+                .migrate()
+                .migrations
+        }
     }
 
-    fun clean() {
-        flyWay.clean()
-    }
+    fun runMigration(): Int = migratedOutput.size
 
-    fun runMigration(): Int =
-        flyWay
-            .migrate()
-            .migrations
-            .size
+    fun truncateTables() {
+        dbSession.session { session ->
+            val tabeller =
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        """
+                        select tablename from pg_tables
+                        where schemaname = 'public' and tablename != 'flyway_schema_history'
+                        """.trimIndent(),
+                    ).map { it.string("tablename") }.asList,
+                )
+
+            if (tabeller.isEmpty()) return@session
+
+            val tabellListe = tabeller.joinToString(", ") { """"public"."$it"""" }
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    """truncate table $tabellListe restart identity cascade""",
+                ).asExecute,
+            )
+        }
+    }
 }
 
 private val ANTALL_TESTER_I_PARALLELL = System.getProperty("junit.jupiter.execution.parallel.config.fixed.parallelism")?.toInt() ?: 1
@@ -54,8 +83,11 @@ internal object Postgres {
             tilgjengeligeTestsesjoner.poll(Duration.ofSeconds(20).toSeconds(), TimeUnit.SECONDS) ?: error("Fikk ikke tak i databasesesjon!")
         try {
             logger.info { "Fikk tak i database..." }
+            testContext.runMigration()
             block(testContext)
         } finally {
+            logger.info { "Tømmer tabeller for innhold..." }
+            testContext.truncateTables()
             logger.info { "Gir databasen tilbake..." }
             tilgjengeligeTestsesjoner.offer(testContext)
         }
@@ -65,48 +97,34 @@ internal object Postgres {
         logger.info { "Oppretter $antall testdatabaser..." }
         return (1..antall)
             .map { "testdb_$it" }
-            .map { databasenavn ->
-                logger.info { "Initialiserer $databasenavn" }
-                logger.info { "oppretter db for $databasenavn" }
-                instance.createConnection("").use { conn ->
-                    conn.createStatement().execute("create database $databasenavn")
-                }
-                logger.info { "oppretter testsesjon for $databasenavn" }
-                createTestSession(instance.withDatabaseName(databasenavn))
-            }
+            .map { databasenavn -> opprettTilkobling(databasenavn) }
     }
 
-    private fun createTestSession(instance: PostgreSQLContainer): DBTestContext {
-        val hikariConfig =
-            HikariConfig().apply {
-                jdbcUrl = instance.jdbcUrl
-                username = instance.username
-                password = instance.password
-                maximumPoolSize = 4
-                minimumIdle = 0
-            }
-        val flywayConfig =
-            HikariConfig().apply {
-                hikariConfig.copyStateTo(this)
-            }
+    private fun opprettTilkobling(databasenavn: String): DBTestContext {
+        logger.info { "Initialiserer $databasenavn" }
+        logger.info { "oppretter db for $databasenavn" }
+        instance.createConnection("").use { conn ->
+            conn.createStatement().execute("create database $databasenavn")
+        }
+        logger.info { "oppretter testsesjon for $databasenavn" }
+        return createTestSession(databasenavn)
+    }
 
-        val dataSource = lazy { HikariDataSource(hikariConfig) }
-        val flywayDataSource = lazy { HikariDataSource(flywayConfig) }
-
-        return DBTestContext(DatabaseSession(dataSource), flywayDataSource)
+    private fun createTestSession(databasenavn: String): DBTestContext {
+        val connectionConfig =
+            instance.withDatabaseName(databasenavn).let { instanceWithDbName ->
+                HikariConfig().apply {
+                    jdbcUrl = instanceWithDbName.jdbcUrl
+                    username = instanceWithDbName.username
+                    password = instanceWithDbName.password
+                }
+            }
+        return DBTestContext(connectionConfig)
     }
 }
 
 internal inline fun withMigratedDb(crossinline block: DBTestContext.() -> Unit) {
-    withCleanDb {
-        runMigration()
-        block()
-    }
-}
-
-internal inline fun withCleanDb(crossinline block: DBTestContext.() -> Unit) {
     Postgres.withTestContext { context ->
-        context.clean()
         block(context)
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/PostgresMigrationTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/PostgresMigrationTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 class PostgresMigrationTest {
     @Test
     fun `Migration scripts are applied successfully`() {
-        withCleanDb {
+        withMigratedDb {
             val migrations = runMigration()
             migrations shouldBeExactly 25
         }

--- a/modell/src/test/kotlin/no/nav/dagpenger/modell/PersonTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/modell/PersonTest.kt
@@ -2,14 +2,14 @@ package no.nav.dagpenger.modell
 
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import no.nav.dagpenger.modell.hjelpere.juli
-import no.nav.dagpenger.modell.hjelpere.juni
-import no.nav.dagpenger.modell.hjelpere.mai
 import no.nav.dagpenger.modell.BehandlingObservatør.BehandlingFerdig
 import no.nav.dagpenger.modell.hendelser.EksternId
 import no.nav.dagpenger.modell.hendelser.ManuellId
 import no.nav.dagpenger.modell.hendelser.StartHendelse
 import no.nav.dagpenger.modell.hendelser.StartHendelseResultat
+import no.nav.dagpenger.modell.hjelpere.juli
+import no.nav.dagpenger.modell.hjelpere.juni
+import no.nav.dagpenger.modell.hjelpere.mai
 import no.nav.dagpenger.opplysning.Forretningsprosess
 import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysninger


### PR DESCRIPTION
Mulig design for å kjøre databasetester i parallell.

Scenario-testene kjøres på rundt 23 sekunder samlet.

Algoritmen er slik:

fyrer opp én testcontainer
lager en liste av n potensielle testsesjoner (med laziness sånn at datasourcen ikke gjør oppkobling med en gang)
når en test trenger en db så tar den 1 stk testsesjon fra listen, eller venter om det ikke er noen ledige
når testen er ferdig returneres testsesjonen til listen
Mulig forbedringer:
hvis bottleneck er den konstante Flyway-migreringen så kan vi ha et design hvor vi migrerer/oppretter tabeller én gang, og
heller tømme databasen manuelt med flere TRUNCATE ... statements etter hver test.