### PR TITLE
refactor: Migrer til Jackson 3.x og fjern naisful-app

### DIFF
--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/mottak/SamordningHendelseMottak.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/mottak/SamordningHendelseMottak.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.regel.mottak
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDateTime
@@ -17,6 +16,7 @@ import no.nav.dagpenger.regel.hendelse.OpprettBehandlingHendelse
 import no.nav.dagpenger.regelverk.HendelseMottaker
 import no.nav.dagpenger.regelverk.melding.KafkaMelding
 import no.nav.dagpenger.uuid.UUIDv7
+import tools.jackson.databind.JsonNode
 
 class SamordningHendelseMottak(
     rapidsConnection: RapidsConnection,

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/mottak/SøknadInnsendtMottak.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/mottak/SøknadInnsendtMottak.kt
@@ -73,7 +73,10 @@ class SøknadInnsendtMessage(
 ) : KafkaMelding(packet) {
     override val ident get() = packet["ident"].asText()
     private val søknadId = packet["søknadId"].asUUID()
-    private val søknadstype = packet["type"].textValue()?.let { Søknadstype.valueOf(it) } ?: Søknadstype.NySøknad
+    private val søknadstype =
+        packet["type"].let { node ->
+            if (node.isMissingNode) Søknadstype.NySøknad else Søknadstype.valueOf(node.textValue())
+        }
 
     internal val hendelse: SøknadInnsendtHendelse
         get() {

--- a/mediator/build.gradle.kts
+++ b/mediator/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(libs.bundles.jackson)
 
     implementation(libs.bundles.postgres)
-    implementation("com.fasterxml.jackson.module:jackson-module-blackbird:${libs.versions.jackson.get()}")
+    implementation("tools.jackson.module:jackson-module-blackbird:${libs.versions.jackson.get()}")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.7.3")
 
@@ -34,7 +34,9 @@ dependencies {
     implementation(libs.bundles.ktor.server)
     implementation("io.ktor:ktor-server-core-jvm:${libs.versions.ktor.get()}")
     implementation("io.ktor:ktor-server-swagger:${libs.versions.ktor.get()}")
-    implementation("com.github.navikt.tbd-libs:naisful-app:2025.11.04-10.54-c831038e")
+    implementation("io.ktor:ktor-server-content-negotiation:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-status-pages:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-serialization-jackson3:${libs.versions.ktor.get()}")
 
     testImplementation("io.kotest:kotest-assertions-core-jvm:${libs.versions.kotest.get()}")
 
@@ -43,7 +45,8 @@ dependencies {
     testImplementation(libs.mock.oauth2.server)
     testImplementation(libs.bundles.postgres.test)
     testImplementation("io.ktor:ktor-server-test-host-jvm:${libs.versions.ktor.get()}")
-    testImplementation("com.github.navikt.tbd-libs:naisful-test-app:2025.11.04-10.54-c831038e")
+    testImplementation("io.ktor:ktor-client-content-negotiation:${libs.versions.ktor.get()}")
+    testImplementation("io.ktor:ktor-serialization-jackson3:${libs.versions.ktor.get()}")
     testImplementation("com.approvaltests:approvaltests:22.3.3")
 }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
@@ -1,9 +1,13 @@
 package no.nav.dagpenger.behandling.mediator
 
-import com.github.navikt.tbd_libs.naisful.naisApp
 import com.github.navikt.tbd_libs.rapids_and_rivers.KafkaRapid
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.ContentType
+import io.ktor.serialization.jackson3.JacksonConverter
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
 import io.micrometer.core.instrument.Clock
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
@@ -21,7 +25,6 @@ import no.nav.dagpenger.ferietillegg.FerietilleggRegistrering
 import no.nav.dagpenger.regel.DagpengerRegistrering
 import no.nav.dagpenger.regelverk.RegelverkRegistrering
 import no.nav.helse.rapids_rivers.RapidApplication
-import org.slf4j.LoggerFactory
 
 internal class ApplicationBuilder(
     config: Map<String, String>,
@@ -48,31 +51,27 @@ internal class ApplicationBuilder(
         RapidApplication.create(
             env = config,
             builder = {
-                withKtor { preStopHook, rapid ->
-                    runtime =
-                        BehandlingRuntime(
-                            dbSession = postgresDataSourceBuilder.dbsession,
-                            rapidsConnection = rapid,
-                            auditlogg = ApiAuditlogg(AktivitetsloggMediator(), rapid),
-                            regelverk = regelverk,
-                        ) { ident: String -> ApiMessageContext(rapid, ident) }
-
-                    naisApp(
-                        meterRegistry = meterRegistry,
-                        objectMapper = objectMapper,
-                        applicationLogger = LoggerFactory.getLogger("ApplicationLogger"),
-                        callLogger = LoggerFactory.getLogger("CallLogger"),
-                        aliveCheck = rapid::isReady,
-                        readyCheck = rapid::isReady,
-                        preStopHook = preStopHook::handlePreStopRequest,
-                        statusPagesConfig = { statusPagesConfig() },
-                    ) {
-                        runtime.api(this)
-                        simuleringApi()
+                withKtorModule {
+                    install(ContentNegotiation) {
+                        register(ContentType.Application.Json, JacksonConverter(objectMapper))
                     }
+                    install(StatusPages) {
+                        statusPagesConfig()
+                    }
+                    runtime.api(this)
+                    simuleringApi()
                 }
             },
+            meterRegistry = meterRegistry,
         ) { engine, rapidsConnection: KafkaRapid ->
+            runtime =
+                BehandlingRuntime(
+                    dbSession = postgresDataSourceBuilder.dbsession,
+                    rapidsConnection = rapidsConnection,
+                    auditlogg = ApiAuditlogg(AktivitetsloggMediator(), rapidsConnection),
+                    regelverk = regelverk,
+                ) { ident: String -> ApiMessageContext(rapidsConnection, ident) }
+
             runtime.registrerMottak()
 
             rapidsConnection.register(
@@ -102,5 +101,11 @@ internal class ApplicationBuilder(
         BehandleMeldekort(
             runtime.meldekortBehandlingskø(rapidsConnection),
         ).start()
+    }
+
+    override fun onShutdownComplete(rapidsConnection: RapidsConnection) {
+        logger.info { "Forsøker å lukke datasource..." }
+        dataSource.close()
+        logger.info { "Lukket datasource" }
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/JsonMapper.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/JsonMapper.kt
@@ -1,18 +1,65 @@
 package no.nav.dagpenger.behandling.mediator
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.blackbird.BlackbirdModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.dagpenger.inntekt.v1.InntektKlasse
+import no.nav.dagpenger.inntekt.v1.KlassifisertInntekt
+import no.nav.dagpenger.inntekt.v1.KlassifisertInntektMåned
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.blackbird.BlackbirdModule
+import tools.jackson.module.kotlin.KotlinModule
+import java.time.YearMonth
+import no.nav.dagpenger.inntekt.v1.Inntekt as InntektV1
 
 val objectMapper: ObjectMapper =
-    jacksonObjectMapper()
-        .registerModule(JavaTimeModule())
-        .registerModule(BlackbirdModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-        // OpenAPI-generator klarer ikke optional-felter. Derfor må vi eksplisitt fjerne null-verdier
-        .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
+    JsonMapper
+        .builder()
+        .addModule(KotlinModule.Builder().build())
+        .addModule(BlackbirdModule())
+        .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_NULL) }
+        .build()
+
+fun InntektV1.tilJsonNode(): JsonNode =
+    objectMapper.valueToTree(
+        mapOf(
+            "inntektsId" to inntektsId,
+            "inntektsListe" to
+                inntektsListe.map { måned ->
+                    mapOf(
+                        "årMåned" to måned.årMåned.toString(),
+                        "klassifiserteInntekter" to
+                            måned.klassifiserteInntekter.map { klassifisertInntekt ->
+                                mapOf(
+                                    "beløp" to klassifisertInntekt.beløp,
+                                    "inntektKlasse" to klassifisertInntekt.inntektKlasse.name,
+                                )
+                            },
+                        "harAvvik" to måned.harAvvik,
+                    )
+                },
+            "manueltRedigert" to manueltRedigert,
+            "sisteAvsluttendeKalenderMåned" to sisteAvsluttendeKalenderMåned.toString(),
+        ),
+    )
+
+fun JsonNode.tilInntektV1(): InntektV1 =
+    InntektV1(
+        inntektsId = this["inntektsId"].asText(),
+        inntektsListe =
+            this["inntektsListe"].toList().map { måned ->
+                KlassifisertInntektMåned(
+                    årMåned = YearMonth.parse(måned["årMåned"].asText()),
+                    klassifiserteInntekter =
+                        måned["klassifiserteInntekter"].toList().map { klassifisertInntekt ->
+                            KlassifisertInntekt(
+                                beløp = klassifisertInntekt["beløp"].decimalValue(),
+                                inntektKlasse = InntektKlasse.valueOf(klassifisertInntekt["inntektKlasse"].asText()),
+                            )
+                        },
+                    harAvvik = måned["harAvvik"].asBoolean(),
+                )
+            },
+        manueltRedigert = this["manueltRedigert"]?.takeUnless { it.isMissingNode || it.isNull }?.asBoolean() ?: false,
+        sisteAvsluttendeKalenderMåned = YearMonth.parse(this["sisteAvsluttendeKalenderMåned"].asText()),
+    )

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/MessageMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/MessageMediator.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.behandling.mediator
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.withMDC
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
@@ -52,6 +51,7 @@ import no.nav.dagpenger.opplysning.Opplysningstype
 import no.nav.dagpenger.regelverk.HendelseMottaker
 import no.nav.dagpenger.regelverk.melding.KafkaMelding
 import no.nav.dagpenger.regelverk.melding.MeldingRepository
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 internal class MessageMediator(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/OpplysningSvarBygger.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/OpplysningSvarBygger.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.behandling.mediator
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDate
 import no.nav.dagpenger.behandling.mediator.objectMapper
 import no.nav.dagpenger.behandling.modell.hendelser.OpplysningSvar
@@ -12,6 +11,7 @@ import no.nav.dagpenger.opplysning.verdier.Barn
 import no.nav.dagpenger.opplysning.verdier.BarnListe
 import no.nav.dagpenger.regel.Behov.Barnetillegg
 import no.nav.dagpenger.regel.Behov.BarnetilleggV2
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 class OpplysningSvarBygger<T : Any>(
@@ -47,7 +47,7 @@ fun barnMapper(
         Barnetillegg ->
             BarnListe(
                 barn =
-                    verdi.map {
+                    verdi.toList().map {
                         Barn(
                             fødselsdato = it["fødselsdato"].asLocalDate(),
                             fornavnOgMellomnavn = it["fornavnOgMellomnavn"]?.asText(),
@@ -61,7 +61,7 @@ fun barnMapper(
             BarnListe(
                 søknadbarnId = verdi["søknadbarnId"].asUUID(),
                 barn =
-                    verdi["barn"].map {
+                    verdi["barn"].toList().map {
                         Barn(
                             fødselsdato = it["fødselsdato"].asLocalDate(),
                             fornavnOgMellomnavn = it["fornavnOgMellomnavn"]?.asText(),

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/Vedtak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/Vedtak.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.behandling.mediator
 
-import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageProblems
 import no.nav.dagpenger.behandling.api.models.BehandletAvDTO
@@ -69,6 +68,7 @@ import no.nav.dagpenger.regel.regelsett.vilkår.TapAvArbeidsinntektOgArbeidstid.
 import no.nav.dagpenger.regel.regelsett.vilkår.Utdanning
 import no.nav.dagpenger.regel.regelsett.vilkår.Utestengning
 import no.nav.dagpenger.regel.regelsett.vilkår.Verneplikt
+import tools.jackson.databind.node.ObjectNode
 import java.time.LocalDateTime
 
 fun Behandling.VedtakOpplysninger.lagVedtakDTO(ident: Ident): VedtakDTO {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/auth/AuthFactory.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/api/auth/AuthFactory.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.behandling.mediator.api.auth
 
 import com.auth0.jwk.JwkProviderBuilder
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.DeserializationFeature
 import com.natpryce.konfig.PropertyGroup
 import com.natpryce.konfig.getValue
 import com.natpryce.konfig.stringType
@@ -11,12 +10,14 @@ import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
-import io.ktor.serialization.jackson.jackson
+import io.ktor.http.ContentType
+import io.ktor.serialization.jackson3.JacksonConverter
 import io.ktor.server.auth.jwt.JWTAuthenticationProvider
 import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.behandling.konfigurasjon.Configuration
 import no.nav.dagpenger.behandling.mediator.api.auth.validering.autoriser
 import no.nav.dagpenger.behandling.mediator.api.auth.validering.autoriserAdminTilgang
+import no.nav.dagpenger.behandling.mediator.objectMapper
 import java.net.URI
 import java.net.URL
 import java.util.concurrent.TimeUnit
@@ -89,8 +90,6 @@ private data class OpenIdConfiguration(
 private val httpClient =
     HttpClient(CIO) {
         install(ContentNegotiation) {
-            jackson {
-                configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            }
+            register(ContentType.Application.Json, JacksonConverter(objectMapper))
         }
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/ArenaOppgaveMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/ArenaOppgaveMottak.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.behandling.mediator.mottak
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
@@ -15,6 +14,7 @@ import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.mottak.SakRepository.Behandling
 import no.nav.dagpenger.behandling.modell.Behandling.TilstandType
 import no.nav.dagpenger.regel.OpplysningsTyper
+import tools.jackson.databind.JsonNode
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/MeldekortInnsendtMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/MeldekortInnsendtMottak.kt
@@ -112,13 +112,13 @@ internal class MeldekortInnsendtMessage(
                             ident = packet["kilde"]["ident"].asText(),
                         ),
                     dager =
-                        packet["dager"].map { dag ->
+                        packet["dager"].toList().map { dag ->
                             Dag(
                                 dato = dag["dato"].asLocalDate(),
                                 // todo: Vi må få dette feltet fra team ramp.
                                 meldt = dag["meldt"]?.takeIf { !it.isMissingOrNull() }?.asBoolean() ?: true,
                                 aktiviteter =
-                                    dag["aktiviteter"].map {
+                                    dag["aktiviteter"].toList().map {
                                         MeldekortAktivitet(
                                             type =
                                                 when (it["type"].asText()) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/OpplysningSvarMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/OpplysningSvarMottak.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.behandling.mediator.mottak
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDate
@@ -20,7 +19,7 @@ import no.nav.dagpenger.behandling.mediator.asUUID
 import no.nav.dagpenger.behandling.mediator.barnMapper
 import no.nav.dagpenger.behandling.mediator.melding.HåndterbarKafkaMelding
 import no.nav.dagpenger.behandling.mediator.mottak.SvarStrategi.Svar
-import no.nav.dagpenger.behandling.mediator.objectMapper
+import no.nav.dagpenger.behandling.mediator.tilInntektV1
 import no.nav.dagpenger.behandling.modell.hendelser.OpplysningSvar
 import no.nav.dagpenger.behandling.modell.hendelser.OpplysningSvar.Tilstand
 import no.nav.dagpenger.behandling.modell.hendelser.OpplysningSvarHendelse
@@ -46,6 +45,7 @@ import no.nav.dagpenger.opplysning.ULID
 import no.nav.dagpenger.opplysning.verdier.Beløp
 import no.nav.dagpenger.opplysning.verdier.Inntekt
 import no.nav.dagpenger.opplysning.verdier.Ulid
+import tools.jackson.databind.JsonNode
 import java.time.LocalDate
 import java.util.UUID
 
@@ -167,7 +167,12 @@ internal class OpplysningSvarMessage(
                         }
                     }
 
-                val utledetAv = packet["@utledetAv"][typeNavn]?.map { it.asUUID() } ?: emptyList()
+                val utledetAv =
+                    packet["@utledetAv"][typeNavn]
+                        ?.takeUnless { it.isMissingNode || it.isNull }
+                        ?.toList()
+                        ?.map { it.asUUID() }
+                        ?: emptyList()
 
                 svarer.forEach { svar ->
                     logger.info {
@@ -268,7 +273,7 @@ private object ListeSvar : SvarStrategi {
     ): List<Svar>? {
         if (!svar.isArray) return null
         if (!svar.all { it.isObject && it.has("verdi") }) return null
-        return svar.map { item ->
+        return svar.toList().map { item ->
             Svar(
                 item["verdi"],
                 item["status"]?.asText()?.let { Tilstand.valueOf(it) } ?: Tilstand.Faktum,
@@ -326,7 +331,7 @@ private class JsonMapper(
 
             InntektDataType -> {
                 Inntekt(
-                    objectMapper.convertValue(verdi, no.nav.dagpenger.inntekt.v1.Inntekt::class.java),
+                    verdi.tilInntektV1(),
                 ) as T
             }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/RekjørBehandlingMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/mottak/RekjørBehandlingMottak.kt
@@ -69,7 +69,7 @@ internal class RekjørBehandlingMessage(
                 ident,
                 packet["behandlingId"].asUUID(),
                 opprettet,
-                packet["oppfriskOpplysningIder"].map { it.asUUID() },
+                packet["oppfriskOpplysningIder"].toList().map { it.asUUID() },
             )
 
     override fun behandle(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/JsonSerde.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/JsonSerde.kt
@@ -1,11 +1,11 @@
 package no.nav.dagpenger.behandling.mediator.repository
 
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.ObjectReader
-import com.fasterxml.jackson.databind.ObjectWriter
 import no.nav.dagpenger.behandling.mediator.objectMapper
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectReader
+import tools.jackson.databind.ObjectWriter
 import java.io.InputStream
 
 class JsonSerde<T>(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/repository/OpplysningerRepositoryPostgres.kt
@@ -8,6 +8,8 @@ import kotliquery.queryOf
 import no.nav.dagpenger.behandling.mediator.db.DatabaseSession
 import no.nav.dagpenger.behandling.mediator.objectMapper
 import no.nav.dagpenger.behandling.mediator.repository.JsonSerde.Companion.serde
+import no.nav.dagpenger.behandling.mediator.tilInntektV1
+import no.nav.dagpenger.behandling.mediator.tilJsonNode
 import no.nav.dagpenger.opplysning.BarnDatatype
 import no.nav.dagpenger.opplysning.Boolsk
 import no.nav.dagpenger.opplysning.Datatype
@@ -40,7 +42,6 @@ import org.postgresql.util.PGobject
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
-import no.nav.dagpenger.inntekt.v1.Inntekt as InntektV1
 
 internal class OpplysningerRepositoryPostgres(
     private val dbSession: DatabaseSession,
@@ -73,7 +74,6 @@ internal class OpplysningerRepositoryPostgres(
 
         // Legacy serde for å kunne lese gamle verdier lagret med gammel struktur
         private val legazySerdeBarn = objectMapper.serde<List<Barn>>()
-        private val serdeInntekt = objectMapper.serde<InntektV1>()
         private val serdePeriode = objectMapper.serde<Periode>()
     }
 
@@ -307,7 +307,7 @@ internal class OpplysningerRepositoryPostgres(
                 }
 
                 InntektDataType -> {
-                    Inntekt(row.binaryStream("verdi_jsonb").use { serdeInntekt.fromJson(it) })
+                    Inntekt(row.binaryStream("verdi_jsonb").use { objectMapper.readTree(it).tilInntektV1() })
                 }
 
                 PeriodeDataType -> {
@@ -493,7 +493,7 @@ internal class OpplysningerRepositoryPostgres(
                     (verdi as Inntekt).verdi.let {
                         PGobject().apply {
                             type = "jsonb"
-                            value = serdeInntekt.toJson(it)
+                            value = it.tilJsonNode().toString()
                         }
                     },
                 )

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/Behovsløsere.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/Behovsløsere.kt
@@ -1,9 +1,9 @@
 package no.nav.dagpenger.behandling.helpers.scenario
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import no.nav.dagpenger.behandling.mediator.objectMapper
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ObjectNode
 
 internal class Behovsløsere(
     private val rapid: TestRapid,
@@ -37,7 +37,7 @@ internal class Behovsløsere(
         val alleBehov = mutableMapOf<String, JsonNode>()
         val behovMeldinger = uløsteBehov()
         for (melding in behovMeldinger) {
-            for (behovNavn in melding["@behov"].map { it.asText() }) {
+            for (behovNavn in melding["@behov"].toList().map { it.asText() }) {
                 alleBehov[behovNavn] = melding
             }
         }
@@ -49,7 +49,7 @@ internal class Behovsløsere(
 
     fun aktiveBehov(): List<String> =
         uløsteBehov().flatMap { melding ->
-            melding["@behov"].map { it.asText() }
+            melding["@behov"].toList().map { it.asText() }
         }
 
     private fun uløsteBehov(): List<JsonNode> {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/Mennesket.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/Mennesket.kt
@@ -1,11 +1,11 @@
 package no.nav.dagpenger.behandling.helpers.scenario
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import no.nav.dagpenger.behandling.api.models.BehandlingsresultatDTO
 import no.nav.dagpenger.behandling.januar
 import no.nav.dagpenger.behandling.mediator.asUUID
 import no.nav.dagpenger.behandling.mediator.objectMapper
+import no.nav.dagpenger.behandling.mediator.tilJsonNode
 import no.nav.dagpenger.inntekt.v1.Inntekt
 import no.nav.dagpenger.inntekt.v1.InntektKlasse
 import no.nav.dagpenger.inntekt.v1.KlassifisertInntekt
@@ -16,6 +16,7 @@ import no.nav.dagpenger.regel.Behov.BostedslandErNorge
 import no.nav.dagpenger.regel.regelsett.vilkår.Søknadstidspunkt.prøvingsdato
 import no.nav.dagpenger.regel.regelsett.vilkår.Verneplikt
 import no.nav.dagpenger.uuid.UUIDv7
+import tools.jackson.databind.JsonNode
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -203,7 +204,7 @@ internal class Mennesket(
                 Behov.ØnskerDagpengerFraDato to Behovsløsning.Statisk(ønskerFraDato),
                 Behov.ØnsketArbeidstid to Behovsløsning.Statisk(40.0),
                 // Inntekt
-                Behov.Inntekt to Behovsløsning.Statisk(mapOf("verdi" to inntektV1)),
+                Behov.Inntekt to Behovsløsning.Statisk(mapOf("verdi" to inntektV1.tilJsonNode())),
                 // Reell arbeidssøker
                 Behov.KanJobbeDeltid to Behovsløsning.Statisk(true),
                 Behov.KanJobbeHvorSomHelst to Behovsløsning.Statisk(true),

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/SimulertDagpengerSystem.kt
@@ -1,5 +1,4 @@
 package no.nav.dagpenger.behandling.helpers.scenario
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.FailedMessage
@@ -20,6 +19,7 @@ import no.nav.dagpenger.ferietillegg.FerietilleggRegistrering
 import no.nav.dagpenger.regel.DagpengerRegistrering
 import no.nav.dagpenger.regelverk.RegelverkRegistrering
 import org.approvaltests.Approvals
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 import kotlin.random.Random
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/assertions/BehandlingsresultatAssertions.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/helpers/scenario/assertions/BehandlingsresultatAssertions.kt
@@ -1,11 +1,11 @@
 package no.nav.dagpenger.behandling.helpers.scenario.assertions
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.kotlin.treeToValue
 import no.nav.dagpenger.behandling.api.models.RettighetsperiodeDTO
 import no.nav.dagpenger.behandling.mediator.asUUID
 import no.nav.dagpenger.behandling.mediator.objectMapper
 import no.nav.dagpenger.opplysning.Opplysningstype
+import tools.jackson.databind.JsonNode
+import tools.jackson.module.kotlin.treeToValue
 import java.time.LocalDate
 import java.util.UUID
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/BehovMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/BehovMediatorTest.kt
@@ -40,7 +40,7 @@ class BehovMediatorTest {
         mediator.håndter(rapid, hendelse)
 
         with(rapid.inspektør.message(0)) {
-            this["@behov"].map { it.asText() } shouldContainExactly listOf("TestBehov1", "TestBehov2")
+            this["@behov"].toList().map { it.asText() } shouldContainExactly listOf("TestBehov1", "TestBehov2")
 
             this["TestBehov1"].size() shouldBe 2
             this["TestBehov1"]["test1"].asText() shouldBe "test1"
@@ -50,8 +50,8 @@ class BehovMediatorTest {
             this["TestBehov2"]["test2"].asText() shouldBe "test2"
             this["TestBehov2"]["felles"].asText() shouldBe "felles"
 
-            this["@utledetAv"]["TestBehov1"].map { it.asText() }.shouldContainExactly("test1", "felles")
-            this["@utledetAv"]["TestBehov2"].map { it.asText() }.shouldContainExactly("test2", "felles")
+            this["@utledetAv"]["TestBehov1"].toList().map { it.asText() }.shouldContainExactly("test1", "felles")
+            this["@utledetAv"]["TestBehov2"].toList().map { it.asText() }.shouldContainExactly("test2", "felles")
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/BehandlingApiTest.kt
@@ -1,10 +1,5 @@
 package no.nav.dagpenger.behandling.mediator.api
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.github.navikt.tbd_libs.naisful.test.TestContext
+
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
@@ -46,6 +41,8 @@ import no.nav.dagpenger.uuid.UUIDv7
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import tools.jackson.core.type.TypeReference
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.time.LocalDate
 
 internal class BehandlingApiTest {
@@ -644,10 +641,6 @@ internal class BehandlingApiTest {
     }
 
     private companion object {
-        private val objectMapper =
-            jacksonObjectMapper()
-                .registerModule(JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        private val objectMapper = jacksonObjectMapper()
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/SimuleringApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/SimuleringApiTest.kt
@@ -1,10 +1,5 @@
 package no.nav.dagpenger.behandling.mediator.api
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.header
 import io.ktor.client.request.put
@@ -14,8 +9,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import no.nav.dagpenger.behandling.mediator.api.TestApplication.withMockAuthServerAndTestApplication
+import no.nav.dagpenger.behandling.mediator.objectMapper
 import no.nav.dagpenger.behandling.simulering.api.models.BeregningDTO
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.readValue
 import java.time.LocalDate
 
 internal class SimuleringApiTest {
@@ -282,10 +279,6 @@ internal class SimuleringApiTest {
         """.trimIndent()
 
     private companion object {
-        private val objectMapper =
-            jacksonObjectMapper()
-                .registerModule(JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        private val objectMapper = no.nav.dagpenger.behandling.mediator.objectMapper
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/TestApplication.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/api/TestApplication.kt
@@ -1,8 +1,7 @@
 package no.nav.dagpenger.behandling.mediator.api
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.github.navikt.tbd_libs.naisful.test.TestContext
-import com.github.navikt.tbd_libs.naisful.test.naisfulTestApp
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.header
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
@@ -11,12 +10,18 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.content.TextContent
+import io.ktor.serialization.jackson3.JacksonConverter
 import io.ktor.server.application.Application
-import io.micrometer.prometheusmetrics.PrometheusConfig
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.ktor.server.application.install
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.testing.testApplication
 import no.nav.dagpenger.behandling.konfigurasjon.Configuration
 import no.nav.dagpenger.behandling.mediator.objectMapper
 import no.nav.security.mock.oauth2.MockOAuth2Server
+
+class TestContext(
+    val client: HttpClient,
+)
 
 object TestApplication {
     private const val AZUREAD_ISSUER_ID = "azureAd"
@@ -62,17 +67,25 @@ object TestApplication {
         System.setProperty("azure-app.client-id", CLIENT_ID)
         System.setProperty("azure-app.well-known-url", "${mockOAuth2Server.wellKnownUrl(AZUREAD_ISSUER_ID)}")
 
-        return naisfulTestApp(
-            {
-                apply { moduleFunction() }
-            },
-            objectMapper.apply {
-                // OpenAPI-generator klarer ikke optional-felter. Derfor må vi eksplisitt fjerne null-verdier
-                setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
-            },
-            PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
-        ) {
-            test()
+        testApplication {
+            application {
+                install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
+                    register(ContentType.Application.Json, JacksonConverter(objectMapper))
+                }
+                install(StatusPages) {
+                    statusPagesConfig()
+                }
+                moduleFunction()
+            }
+
+            val testClient =
+                createClient {
+                    install(ContentNegotiation) {
+                        register(ContentType.Application.Json, JacksonConverter(objectMapper))
+                    }
+                }
+
+            test(TestContext(testClient))
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/mottak/UtbetalingStatusMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/mottak/UtbetalingStatusMottakTest.kt
@@ -4,12 +4,10 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import no.nav.dagpenger.behandling.mediator.IMessageMediator
 import no.nav.dagpenger.behandling.modell.hendelser.UtbetalingStatus
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class UtbetalingStatusMottakTest {
@@ -20,18 +18,19 @@ class UtbetalingStatusMottakTest {
         UtbetalingStatusMottak(rapidsConnection = testRapid, messageMediator)
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = ["utbetaling_mottatt", "utbetaling_sendt", "utbetaling_feilet", "utbetaling_utført"])
-    fun `vi kan motta utbetalingstatusmeldinger`(event: String) {
-        val message = utbetalingStatusEvent(event)
-        testRapid.sendTestMessage(message)
-        val slot = slot<UtbetalingStatus>()
-        verify(exactly = 1) { messageMediator.behandle(capture(slot), any<UtbetalingStatusMessage>(), any<MessageContext>()) }
-        slot.isCaptured shouldBe true
-        val hendelse = slot.captured
-        hendelse.behandlingId shouldBe UUID.fromString("d290f1ee-6c54-4b01-90e6-d701748f0851")
-        hendelse.ident() shouldBe "12345678901"
-        hendelse.behandletHendelseId shouldBe "654321"
+    @Test
+    fun `vi kan motta utbetalingstatusmeldinger`() {
+        val slots = mutableListOf<UtbetalingStatus>()
+        listOf("utbetaling_mottatt", "utbetaling_sendt", "utbetaling_feilet", "utbetaling_utført").forEach { event ->
+            val message = utbetalingStatusEvent(event)
+            testRapid.sendTestMessage(message)
+        }
+        verify(exactly = 4) { messageMediator.behandle(capture(slots), any<UtbetalingStatusMessage>(), any<MessageContext>()) }
+        slots.forEach { hendelse ->
+            hendelse.behandlingId shouldBe UUID.fromString("d290f1ee-6c54-4b01-90e6-d701748f0851")
+            hendelse.ident() shouldBe "12345678901"
+            hendelse.behandletHendelseId shouldBe "654321"
+        }
     }
 
     private fun utbetalingStatusEvent(string: String) =

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/scenario/BeregningTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/scenario/BeregningTest.kt
@@ -63,9 +63,9 @@ class BeregningTest {
                 }
 
                 // Første forbruksdag er 21, så 11 dager i perioden gir utbetaling
-                utbetalinger shouldHaveSize 11
+                utbetalinger.toList() shouldHaveSize 11
 
-                utbetalinger.sumOf { it["utbetaling"].asInt() } shouldBe 5036
+                utbetalinger.toList().sumOf { it["utbetaling"].asInt() } shouldBe 5036
 
                 with(opplysninger(Beregning.forbrukt)) {
                     none { it.opprinnelse == Opplysningsperiode.Periodestatus.Arvet } shouldBe true
@@ -96,7 +96,7 @@ class BeregningTest {
             meldekortBatch()
 
             behandlingsresultatForslag {
-                utbetalinger.sumOf { it["utbetaling"].asInt() } shouldBe 5036
+                utbetalinger.toList().sumOf { it["utbetaling"].asInt() } shouldBe 5036
 
                 with(opplysninger(Beregning.forbrukt)) {
                     forAll { it.opprinnelse shouldBe Opplysningsperiode.Periodestatus.Ny }
@@ -152,10 +152,10 @@ class BeregningTest {
             meldekortBatch(true)
 
             behandlingsresultat {
-                utbetalinger.sumOf { it["utbetaling"].asInt() } shouldBe 42806
+                utbetalinger.toList().sumOf { it["utbetaling"].asInt() } shouldBe 42806
 
                 // Bare de siste 14 dagene skal markeres som ny for de tilhører siste meldeperiode
-                utbetalinger.count { it["opprinnelse"].asText() == "Ny" } shouldBe 14
+                utbetalinger.toList().count { it["opprinnelse"].asText() == "Ny" } shouldBe 14
 
                 with(opplysninger(Beregning.forbrukt)) {
                     val forbruksdager = map { it.verdi.verdi as Int }
@@ -489,8 +489,8 @@ class BeregningTest {
 
             // Verifiser gammel sats
             behandlingsresultatForslag {
-                val satsPerDag = utbetalinger.map { it["sats"].asInt() }
-                val utbetalingPerDag = utbetalinger.map { it["utbetaling"].asInt() }
+                val satsPerDag = utbetalinger.toList().map { it["sats"].asInt() }
+                val utbetalingPerDag = utbetalinger.toList().map { it["utbetaling"].asInt() }
                 satsPerDag.shouldContainExactly(762, 762, 762, 762, 762, 762, 762, 762, 762, 762, 762)
                 utbetalingPerDag.shouldContainExactly(435, 435, 0, 0, 435, 435, 435, 435, 438, 0, 0)
             }
@@ -505,8 +505,8 @@ class BeregningTest {
 
             // Verifiser at vi får ny og høyere sats fra og med 25. juni
             behandlingsresultatForslag {
-                val satsPerDag = utbetalinger.map { it["sats"].asInt() }
-                val utbetalingPerDag = utbetalinger.map { it["utbetaling"].asInt() }
+                val satsPerDag = utbetalinger.toList().map { it["sats"].asInt() }
+                val utbetalingPerDag = utbetalinger.toList().map { it["utbetaling"].asInt() }
                 satsPerDag.shouldContainExactly(762, 762, 762, 762, 1074, 1074, 1074, 1074, 1074, 1074, 1074)
                 utbetalingPerDag.shouldContainExactly(509, 510, 0, 0, 717, 717, 717, 717, 721, 0, 0)
             }

--- a/modell/src/test/kotlin/no/nav/dagpenger/behandling/cucumber/CucumberSetup.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/behandling/cucumber/CucumberSetup.kt
@@ -1,19 +1,12 @@
 package no.nav.dagpenger.behandling.cucumber
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.cucumber.java8.No
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.lang.reflect.Type
 
 class CucumberSetup : No {
     companion object {
-        private val objectMapper =
-            jacksonObjectMapper()
-                .registerModule(JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        private val objectMapper = jacksonObjectMapper()
     }
 
     init {

--- a/openapi/build.gradle.kts
+++ b/openapi/build.gradle.kts
@@ -33,7 +33,7 @@ ktlint {
 }
 
 dependencies {
-    implementation(libs.jackson.annotation)
+    implementation(libs.jackson.databind)
 }
 
 fabrikt {

--- a/regelverk/src/main/kotlin/no/nav/dagpenger/regelverk/JsonNodeExtensions.kt
+++ b/regelverk/src/main/kotlin/no/nav/dagpenger/regelverk/JsonNodeExtensions.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.regelverk
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 fun JsonNode.asUUID(): UUID = this.asText().let { UUID.fromString(it) }

--- a/regelverk/src/main/kotlin/no/nav/dagpenger/regelverk/melding/KafkaMelding.kt
+++ b/regelverk/src/main/kotlin/no/nav/dagpenger/regelverk/melding/KafkaMelding.kt
@@ -1,8 +1,8 @@
 package no.nav.dagpenger.regelverk.melding
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.asLocalDateTime
+import tools.jackson.databind.JsonNode
 import java.util.UUID
 
 abstract class KafkaMelding(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20251205.234.05353f")
+            from("no.nav.dagpenger:dp-version-catalog:20260516.254.df0c40")
         }
     }
 }


### PR DESCRIPTION
## Endringer

- Oppgraderer dp-version-catalog til 20260516.254.df0c40 (Jackson 3.1.2)
- Erstatter `com.fasterxml.jackson.databind` med `tools.jackson.databind`
- Fjerner naisful-app, bruker Ktor-plugins direkte (ContentNegotiation, StatusPages)
- Rewriter JsonMapper med Jackson 3 builder-pattern
- Legger til manuell InntektV1 serialisering (`tilJsonNode`/`tilInntektV1`) pga. Jackson 3 ikke serialiserer non-ASCII property-navn korrekt
- Erstatter naisfulTestApp med ktor testApplication direkte
- Fikser `JsonNode.map` → `JsonNode.toList().map` (Jackson 3 breaking change)
- Fikser `MissingNode.textValue()` som nå kaster exception

## Bakgrunn

Jackson 3 endrer package-struktur fra `com.fasterxml.jackson` til `tools.jackson`. Annotations forblir i `com.fasterxml.jackson.annotation`.

naisful-app erstattes med direkte bruk av Ktor-plugins for bedre kontroll over applikasjonsoppsett.