### PR TITLE
feat: Legg til ArchUnit arkitekturtester

### DIFF
--- a/mediator/build.gradle.kts
+++ b/mediator/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     testImplementation("io.ktor:ktor-client-content-negotiation:${libs.versions.ktor.get()}")
     testImplementation("io.ktor:ktor-serialization-jackson3:${libs.versions.ktor.get()}")
     testImplementation("com.approvaltests:approvaltests:22.3.3")
+    testImplementation("com.tngtech.archunit:archunit-junit5:1.4.0")
 }
 
 application {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/ApplicationBuilder.kt
@@ -102,4 +102,10 @@ internal class ApplicationBuilder(
             runtime.meldekortBehandlingskø(rapidsConnection),
         ).start()
     }
+
+    override fun onShutdownComplete(rapidsConnection: RapidsConnection) {
+        logger.info { "Forsøker å lukke datasource..." }
+        postgresDataSourceBuilder.close()
+        logger.info { "Lukket datasource" }
+    }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/db/DatabaseSession.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/db/DatabaseSession.kt
@@ -20,6 +20,12 @@ data class DatabaseSession(
 ) {
     fun <R> session(block: (Session) -> R): R = sessionOf(dataSource.value).use(block)
 
+    fun close() {
+        if (dataSource.isInitialized()) {
+            (dataSource.value as? AutoCloseable)?.close()
+        }
+    }
+
     fun transaction(transactionBlock: PostgresUnitOfWork.() -> Unit) {
         session { session ->
             session.connection.underlying.withTransaction {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/db/PostgresDataSourceBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/behandling/mediator/db/PostgresDataSourceBuilder.kt
@@ -53,6 +53,10 @@ internal class PostgresDataSourceBuilder {
 
     val dbsession = DatabaseSession(lazy { HikariDataSource(hikariConfig) })
 
+    internal fun close() {
+        dbsession.close()
+    }
+
     internal fun runMigration() {
         val config =
             HikariConfig().apply {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/ArkitekturTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/behandling/mediator/ArkitekturTest.kt
@@ -1,0 +1,90 @@
+package no.nav.dagpenger.behandling.mediator
+
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
+import org.junit.jupiter.api.Test
+
+class ArkitekturTest {
+    private val klasser =
+        ClassFileImporter()
+            .withImportOption(ImportOption.DoNotIncludeTests())
+            .importPackages("no.nav.dagpenger")
+
+    // -- Modulgrenser --
+
+    @Test
+    fun `ingen andre pakker skal avhenge av mediator`() {
+        noClasses()
+            .that()
+            .resideOutsideOfPackage("..behandling.mediator..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..behandling.mediator..")
+            .check(klasser)
+    }
+
+    // -- Infrastruktur-isolasjon --
+
+    @Test
+    fun `kun mediator skal bruke kotliquery`() {
+        noClasses()
+            .that()
+            .resideOutsideOfPackage("..behandling.mediator..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("kotliquery..")
+            .check(klasser)
+    }
+
+    @Test
+    fun `kun mediator skal bruke Ktor`() {
+        noClasses()
+            .that()
+            .resideOutsideOfPackage("..behandling.mediator..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("io.ktor..")
+            .check(klasser)
+    }
+
+    // -- Transportuavhengighet --
+
+    @Test
+    fun `domenemodell og opplysninger skal ikke avhenge av Jackson`() {
+        noClasses()
+            .that()
+            .resideInAnyPackage("..behandling.modell..", "..dagpenger.opplysning..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage("com.fasterxml.jackson..", "tools.jackson..")
+            .check(klasser)
+    }
+
+    // -- Navnekonvensjoner --
+
+    @Test
+    fun `RepositoryPostgres-klasser skal ligge i repository-pakken`() {
+        classes()
+            .that()
+            .haveSimpleNameEndingWith("RepositoryPostgres")
+            .and()
+            .doNotHaveSimpleName("SakRepositoryPostgres")
+            .should()
+            .resideInAPackage("..repository..")
+            .check(klasser)
+    }
+
+    // -- Sykliske avhengigheter --
+
+    @Test
+    fun `ingen sykliske avhengigheter mellom moduler`() {
+        slices()
+            .matching("no.nav.dagpenger.behandling.(*)..")
+            .should()
+            .beFreeOfCycles()
+            .check(klasser)
+    }
+}


### PR DESCRIPTION
## Endringer

Legger til ArchUnit-baserte arkitekturtester som håndhever modulgrenser:

| Regel | Beskrivelse |
|-------|-------------|
| Mediator-isolasjon | Ingen pakker utenfor mediator skal avhenge av mediator |
| Kotliquery-isolasjon | Kun mediator skal bruke kotliquery |
| Ktor-isolasjon | Kun mediator skal bruke Ktor |
| Jackson-uavhengighet | Domenemodell og opplysninger skal ikke avhenge av Jackson |
| Navnekonvensjon | RepositoryPostgres-klasser skal ligge i repository-pakken |
| Sykliske avhengigheter | Ingen sykliske avhengigheter innenfor behandling-modulen |

### Bonus-fix
- Legger til `close()` på `DatabaseSession` og `PostgresDataSourceBuilder` for graceful shutdown
- Fikser `ApplicationBuilder.onShutdownComplete` som refererte til udefinert `dataSource`

### Neste steg
Package-rename (`no.nav.dagpenger.behandling.*` → `no.nav.dagpenger.*`) gjør at sykkel-testen kan sjekke på tvers av alle moduler, ikke bare innenfor `behandling`.