### PR TITLE
fix: Persister behandletVed for korrekt cleanup av deaktiverte regelsett

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/repository/OpplysningerRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/repository/OpplysningerRepositoryPostgres.kt
@@ -246,6 +246,7 @@ internal class OpplysningerRepositoryPostgres(
             val erstatterId = this.uuidOrNull("erstatter_id")
 
             val kildeId = this.uuidOrNull("kilde_id")
+            val behandletVed = this.localDateOrNull("behandlet_ved")
 
             return OpplysningRad(
                 opplysingerId = opplysingerId,
@@ -259,6 +260,7 @@ internal class OpplysningerRepositoryPostgres(
                 kilde = null,
                 opprettet = opprettet,
                 erstatter = erstatterId,
+                behandletVed = behandletVed,
             )
         }
 
@@ -406,6 +408,7 @@ internal class OpplysningerRepositoryPostgres(
                             "opplysning_id" to opplysning.id,
                             "datatype" to datatype.navn(),
                             "erstatter_id" to opplysning.erstatter?.id,
+                            "behandlet_ved" to opplysning.behandletVed,
                         ) + verdi
                     }
                 }
@@ -417,11 +420,11 @@ internal class OpplysningerRepositoryPostgres(
                     WITH ins AS (SELECT opplysningstype_id FROM opplysningstype WHERE uuid = :typeUuid AND datatype = :datatype)
                     INSERT
                     INTO opplysning (opplysninger_id, id, status, opplysningstype_id, kilde_id, gyldig_fom, gyldig_tom, opprettet, datatype,
-                                     verdi_heltall, verdi_desimaltall, verdi_dato, verdi_boolsk, verdi_string, verdi_jsonb, erstatter_id)
+                                     verdi_heltall, verdi_desimaltall, verdi_dato, verdi_boolsk, verdi_string, verdi_jsonb, erstatter_id, behandlet_ved)
                     VALUES (:opplysningerId, :id, :status, (SELECT opplysningstype_id FROM ins), :kilde_id, :fom::timestamp,
                             :tom::timestamp, :opprettet, :datatype, :verdi_heltall, :verdi_desimaltall, :verdi_dato, :verdi_boolsk,
-                            :verdi_string, :verdi_jsonb, :erstatter_id)
-                    ON CONFLICT(id) DO UPDATE SET erstatter_id=:erstatter_id
+                            :verdi_string, :verdi_jsonb, :erstatter_id, :behandlet_ved)
+                    ON CONFLICT(id) DO UPDATE SET erstatter_id=:erstatter_id, behandlet_ved=:behandlet_ved
                     """.trimIndent(),
                     params,
                 ).krevAtAntallRaderErNøyaktigLik(params.size)
@@ -598,6 +601,7 @@ private fun Collection<OpplysningRad<out Any>>.somOpplysninger(): List<Opplysnin
             }
 
         // Add the Opplysning instance to the map and return it
+        opplysning.behandletVed = behandletVed
         opplysningMap[id] = opplysning
         return opplysning
     }
@@ -627,4 +631,5 @@ private data class OpplysningRad<T : Any>(
     val kilde: Kilde? = null,
     val opprettet: LocalDateTime,
     val erstatter: UUID? = null,
+    val behandletVed: LocalDate? = null,
 )

--- a/mediator/src/main/resources/db/migration/V93__OPPLYSNING_BEHANDLET_VED.sql
+++ b/mediator/src/main/resources/db/migration/V93__OPPLYSNING_BEHANDLET_VED.sql
@@ -1,0 +1,52 @@
+-- Legger til kolonne for å spore hvilken prøvingsdato en opplysning ble behandlet ved.
+-- Brukes av regelkjøringens cleanup for å fjerne opplysninger fra deaktiverte regelsett
+-- selv når fraOgMed < prøvingsdato (f.eks. ønsketDato > søknadsdato).
+ALTER TABLE opplysning ADD COLUMN behandlet_ved DATE DEFAULT NULL;
+
+-- Oppdaterer viewet til å inkludere den nye kolonnen
+DROP VIEW opplysningstabell;
+CREATE OR REPLACE VIEW opplysningstabell AS
+SELECT opplysning.opplysninger_id,
+       opplysning.id,
+       opplysning.status,
+       opplysningstype.datatype,
+       opplysningstype.behov_id AS type_behov_id,
+       opplysningstype.uuid     AS type_uuid,
+       opplysningstype.navn     AS type_navn,
+       opplysning.gyldig_fom,
+       opplysning.gyldig_tom,
+       opplysning.verdi_heltall,
+       opplysning.verdi_desimaltall,
+       opplysning.verdi_dato,
+       opplysning.verdi_boolsk,
+       opplysning.verdi_string,
+       utledning.regel          AS utledet_av,
+       utledning.versjon        AS utledet_versjon,
+       kilde.id                 AS kilde_id,
+       opplysning.opprettet,
+       utledet_av_ids.utledet_av_id,
+       opplysning.verdi_jsonb,
+       opplysning.erstatter_id  AS erstatter_id,
+       opplysningstype.formål   AS type_formål,
+       opplysning.behandlet_ved
+FROM opplysning
+         INNER JOIN
+     opplysningstype ON opplysning.opplysningstype_id = opplysningstype.opplysningstype_id
+         LEFT JOIN
+     kilde ON kilde_id = kilde.id
+
+         -- Lateral subquery: henter regel fra én rad
+         LEFT JOIN LATERAL (
+    SELECT regel, versjon
+    FROM opplysning_utledning
+    WHERE opplysning_id = opplysning.id
+    LIMIT 1
+    ) utledning ON TRUE
+
+    -- Lateral subquery: henter liste med utledet_av-id-er
+         LEFT JOIN LATERAL (
+    SELECT ARRAY_AGG(utledet_av) AS utledet_av_id
+    FROM opplysning_utledet_av
+    WHERE opplysning_id = opplysning.id
+    ) utledet_av_ids ON TRUE
+WHERE opplysning.fjernet IS FALSE;

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/PostgresMigrationTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/PostgresMigrationTest.kt
@@ -8,7 +8,7 @@ class PostgresMigrationTest {
     fun `Migration scripts are applied successfully`() {
         withIsolatedDb {
             val migrations = runMigration()
-            migrations shouldBeExactly 25
+            migrations shouldBeExactly 26
         }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/scenario/ScenarioTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/scenario/ScenarioTest.kt
@@ -41,7 +41,6 @@ import no.nav.dagpenger.regel.regelsett.vilkår.Søknadstidspunkt.søknadIdOpply
 import no.nav.dagpenger.regel.regelsett.vilkår.Søknadstidspunkt.ønsketdato
 import no.nav.dagpenger.regel.regelsett.vilkår.Verneplikt.oppfyllerKravetTilVerneplikt
 import no.nav.dagpenger.scenario.SimulertDagpengerSystem.Companion.nyttScenario
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.UUID
@@ -386,8 +385,7 @@ class ScenarioTest {
     }
 
     @Test
-    @Disabled("Ikke mulig å skru av reell arbeidssøker fra ønsket dato")
-    fun `tester avslag ved for lite inntekt, ikke reell arbeidssøker, og prøvingsdato flyttes til søknadsdato`() {
+    fun `tester avslag ved for lite inntekt, ikke reell arbeidssøker, med avslag fra ønsket dato`() {
         nyttScenario {
             inntektSiste12Mnd = 50000
         }.test {
@@ -415,7 +413,7 @@ class ScenarioTest {
                 opplysninger(Minsteinntekt.minsteinntekt).single().verdi.verdi shouldBe false
                 opplysninger(ReellArbeidssøker.kravTilArbeidssøker) shouldHaveSize 0
 
-                opplysninger shouldHaveSize 43
+                opplysninger shouldHaveSize 52
             }
         }
     }

--- a/mediator/src/test/resources/no/nav/dagpenger/scenario/ScenarioTest.tester avslag ved for lite inntekt, ikke reell arbeidssøker, med avslag fra ønsket dato.approved.txt
+++ b/mediator/src/test/resources/no/nav/dagpenger/scenario/ScenarioTest.tester avslag ved for lite inntekt, ikke reell arbeidssøker, med avslag fra ønsket dato.approved.txt
@@ -1,0 +1,34 @@
+Laget avklaring om HarTilleggsopplysninger
+Opprettet ny behandling
+Behandling endret tilstand til: UnderBehandling
+Behov:
+- ØnskerDagpengerFraDato
+- Fødselsdato
+Laget avklaring om HattLukkedeSakerSiste8Uker
+Laget avklaring om MuligGjenopptak
+Behov:
+- Inntekt
+- KanJobbeDeltid
+- KanJobbeHvorSomHelst
+- HelseTilAlleTyperJobb
+- VilligTilÅBytteYrke
+- ØnsketArbeidstid
+- RegistrertSomArbeidssøker
+- Ordinær
+- Permittert
+- Lønnsgaranti
+- PermittertFiskeforedling
+- Verneplikt
+Laget avklaring om EØSArbeid
+Laget avklaring om InntektNesteKalendermåned
+Laget avklaring om JobbetUtenforNorge
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: Redigert
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: Redigert
+Behov:
+- Inntekt
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: TilGodkjenning
+Behandling endret tilstand til: Ferdig
+Har fattet vedtak med utfall=false

--- a/mediator/src/test/resources/no/nav/dagpenger/scenario/ScenarioTest.tester avslag ved for lite inntekt, ikke reell arbeidssøker, og prøvingsdato flyttes til søknadsdato.approved.txt
+++ b/mediator/src/test/resources/no/nav/dagpenger/scenario/ScenarioTest.tester avslag ved for lite inntekt, ikke reell arbeidssøker, og prøvingsdato flyttes til søknadsdato.approved.txt
@@ -1,0 +1,34 @@
+Laget avklaring om HarTilleggsopplysninger
+Opprettet ny behandling
+Behandling endret tilstand til: UnderBehandling
+Behov:
+- ØnskerDagpengerFraDato
+- Fødselsdato
+Laget avklaring om HattLukkedeSakerSiste8Uker
+Laget avklaring om MuligGjenopptak
+Behov:
+- Inntekt
+- KanJobbeDeltid
+- KanJobbeHvorSomHelst
+- HelseTilAlleTyperJobb
+- VilligTilÅBytteYrke
+- ØnsketArbeidstid
+- RegistrertSomArbeidssøker
+- Ordinær
+- Permittert
+- Lønnsgaranti
+- PermittertFiskeforedling
+- Verneplikt
+Laget avklaring om EØSArbeid
+Laget avklaring om InntektNesteKalendermåned
+Laget avklaring om JobbetUtenforNorge
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: Redigert
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: Redigert
+Behov:
+- Inntekt
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: TilGodkjenning
+Behandling endret tilstand til: Ferdig
+Har fattet vedtak med utfall=false

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysning.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysning.kt
@@ -28,6 +28,10 @@ sealed class Opplysning<T : Any>(
     // Flagg som indikerer om opplysningen har blitt behandlet av regelkjøringen.
     // Default true fordi opplysninger lastet fra DB allerede er behandlet (flagget persisteres ikke).
     var behandlet: Boolean = true,
+    // Hvilken prøvingsdato opplysningen sist ble behandlet ved. Persisteres til DB.
+    // Brukes for å skille opplysninger fra nåværende eval-syklus (kan fjernes ved cleanup)
+    // fra opplysninger fra tidligere eval-sykluser med annen prøvingsdato (skal beskyttes).
+    var behandletVed: LocalDate? = null,
 ) : Klassifiserbart by opplysningstype {
     private val defaultRedigering = Redigerbar { opplysningstype.datatype != ULID }
 

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysninger.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysninger.kt
@@ -35,6 +35,7 @@ class Opplysninger private constructor(
 
     fun <T : Any> leggTil(opplysning: Opplysning<T>) {
         opplysning.behandlet = false
+        opplysning.behandletVed = null
         val eksisterende = finnNullableOpplysning(opplysning.opplysningstype, opplysning.gyldighetsperiode)
 
         if (eksisterende != null) {
@@ -77,8 +78,13 @@ class Opplysninger private constructor(
 
     fun markerBehandlet(dato: LocalDate) {
         egne
-            .filter { it.gyldighetsperiode.inneholder(dato) && !it.behandlet }
-            .forEach { it.behandlet = true }
+            .filter { it.gyldighetsperiode.inneholder(dato) }
+            .forEach {
+                it.behandlet = true
+                // Kun utledede opplysninger trenger behandletVed-sporing for cleanup.
+                // Input-opplysninger (fra behov) skal ikke fjernes av behandletVed-sjekken.
+                if (it.utledetAv != null && it.behandletVed == null) it.behandletVed = dato
+            }
     }
 
     fun ubehandledeDatoer(): List<LocalDate> =

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Regelkjøring.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Regelkjøring.kt
@@ -134,13 +134,13 @@ class Regelkjøring(
         }
 
         // Fjern utledede opplysninger som ikke brukes for å produsere ønsket resultat.
-        // Opplysninger med Saksbehandlerkilde beholdes alltid — de er eksplisitte overstyringer
-        // og skal aldri fjernes av avhengighetsanalyse.
         val brukteOpplysninger = avhengighetsgraf.nødvendigeOpplysninger(opplysninger, ønsketResultat)
         opplysninger.fjernHvis {
-            it.kilde !is Saksbehandlerkilde &&
-                it.opplysningstype !in brukteOpplysninger &&
-                it.gyldighetsperiode.fraOgMed >= prøvingsdato
+            val ikkeGjortAvSaksbehandler = it.kilde !is Saksbehandlerkilde
+            val trengsIkke = it.opplysningstype !in brukteOpplysninger
+            val tilhørerDenneRegelkjøringen = it.gyldighetsperiode.fraOgMed >= prøvingsdato || it.behandletVed == prøvingsdato
+
+            ikkeGjortAvSaksbehandler && trengsIkke && tilhørerDenneRegelkjøringen
         }
 
         opplysninger.markerBehandlet(prøvingsdato)


### PR DESCRIPTION
## Problem

Når ønsketDato ligger fram i tid (prøvingsdato > søknadsdato), klarte ikke regelmotoren å fjerne opplysninger fra deaktiverte regelsett. Cleanup-betingelsen `fraOgMed >= prøvingsdato` feilet fordi opplysningene hadde fraOgMed=søknadsdato som var lavere enn prøvingsdato.

## Løsning

Introduserer `behandletVed`-feltet som sporer hvilken prøvingsdato som sist behandlet en utledet opplysning. Feltet persisteres til DB via ny kolonne og brukes som alternativ cleanup-betingelse:

```kotlin
val tilhørerDenneRegelkjøringen = it.gyldighetsperiode.fraOgMed >= prøvingsdato || it.behandletVed == prøvingsdato

ikkeGjortAvSaksbehandler && trengsIkke && tilhørerDenneRegelkjøringen
```

Kun utledede opplysninger (produsert av regler) får `behandletVed` satt, slik at input-opplysninger fra behov ikke fjernes feilaktig ved periodeskifter.

## Bakoverkompatibilitet

Eksisterende opplysninger har `behandlet_ved = NULL` etter migrering. Da er `null == prøvingsdato` alltid false, og betingelsen faller tilbake til gammel oppførsel. Ved neste eval settes verdien automatisk.