### PR TITLE
F: gjør Prosesskontekst til en aktivitetskontekst for å få med hva so…

### DIFF
--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/MeldekortBeregningPlugin.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/MeldekortBeregningPlugin.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.regel.prosess
 
+import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
 import no.nav.dagpenger.opplysning.LesbarOpplysninger
@@ -25,8 +26,10 @@ class MeldekortBeregningPlugin : ProsessPlugin {
         kontekst: Prosesskontekst,
         meldeperiode: Periode,
     ): Beregningresultat {
+        kontekst.kontekst(this)
         val opplysninger = kontekst.opplysninger
         val gyldighetsperiode = Gyldighetsperiode(meldeperiode.fraOgMed, meldeperiode.tilOgMed)
+        kontekst.info("Beregner meldeperiode: ${gyldighetsperiode.fraOgMed} til ${gyldighetsperiode.tilOgMed}")
 
         val terskelForAntallDagerEnIkkeKanVæreMeldt = TerskelTrekkForSenMelding.forDato(meldeperiode.fraOgMed)
         val antallIkkeMeldtDager =
@@ -68,4 +71,9 @@ class MeldekortBeregningPlugin : ProsessPlugin {
     }
 
     private fun meldeperiode(opplysninger: LesbarOpplysninger): Periode = opplysninger.kunEgne.finnOpplysning(Beregning.meldeperiode).verdi
+
+    override fun toSpesifikkKontekst() =
+        SpesifikkKontekst(
+            "MeldekortBeregningPlugin",
+        )
 }

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/Meldekortprosess.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/Meldekortprosess.kt
@@ -1,4 +1,5 @@
 package no.nav.dagpenger.regel.prosess
+import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Forretningsprosess
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
@@ -53,6 +54,7 @@ class Meldekortprosess : Forretningsprosess(RegelverkDagpenger) {
 
 class Kvotetelling : ProsessPlugin {
     override fun regelkjøringFerdig(kontekst: Prosesskontekst) {
+        kontekst.kontekst(this)
         val opplysninger = kontekst.opplysninger
         val innvilgetStønadsdager = opplysninger.finnOpplysning(antallStønadsdager).verdi
 
@@ -99,4 +101,6 @@ class Kvotetelling : ProsessPlugin {
             )
         }
     }
+
+    override fun toSpesifikkKontekst() = SpesifikkKontekst("Kvotetelling")
 }

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/Omgjøringsprosess.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/Omgjøringsprosess.kt
@@ -1,4 +1,6 @@
 package no.nav.dagpenger.regel.prosess
+import no.nav.dagpenger.aktivitetslogg.Aktivitetskontekst
+import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Forretningsprosess
 import no.nav.dagpenger.opplysning.LesbarOpplysninger
 import no.nav.dagpenger.opplysning.Opplysninger
@@ -67,8 +69,10 @@ class Omgjøringsprosess : Forretningsprosess(RegelverkDagpenger) {
 class OmgjøringBeregningPlugin(
     private val meldekortBeregningPlugin: MeldekortBeregningPlugin,
     private val kvotetelling: Kvotetelling,
-) : ProsessPlugin {
+) : ProsessPlugin,
+    Aktivitetskontekst {
     override fun regelkjøringFerdig(kontekst: Prosesskontekst) {
+        kontekst.kontekst(this)
         val opplysninger = kontekst.opplysninger
         val meldeperioder =
             opplysninger
@@ -77,11 +81,16 @@ class OmgjøringBeregningPlugin(
                 .sortedBy { it.fraOgMed }
 
         // Kjør beregning for hver meldeperiode i kronologisk rekkefølge
+
+        kontekst.info("Start re-beregning for ${meldeperioder.size} meldeperioder ved omgjøring.")
         meldeperioder.forEach { periode ->
+            kontekst.info("Reberegner meldeperiode: $periode")
             meldekortBeregningPlugin.beregnForPeriode(kontekst, periode)
         }
 
         // Kjør kvotetelling etter at alle perioder er beregnet
         kvotetelling.regelkjøringFerdig(kontekst)
     }
+
+    override fun toSpesifikkKontekst() = SpesifikkKontekst("OmgjøringBeregningPlugin")
 }

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/PrøvingsdatoPlugin.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/PrøvingsdatoPlugin.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.regel.prosess
 import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
 import no.nav.dagpenger.opplysning.ProsessPlugin
@@ -10,6 +11,7 @@ import no.nav.dagpenger.regel.regelsett.vilkår.Søknadstidspunkt
 
 class PrøvingsdatoPlugin : ProsessPlugin {
     override fun regelkjøringFerdig(kontekst: Prosesskontekst) {
+        kontekst.kontekst(this)
         val opplysninger = kontekst.opplysninger
         val egne = opplysninger.kunEgne
 
@@ -48,6 +50,8 @@ class PrøvingsdatoPlugin : ProsessPlugin {
 
         kontekst.beOmRekjøring()
     }
+
+    override fun toSpesifikkKontekst() = SpesifikkKontekst("PrøvingsdatoPlugin")
 
     companion object {
         private val logger = KotlinLogging.logger {}

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/RettighetsperiodePlugin.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/RettighetsperiodePlugin.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.regel.prosess
 import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
 import no.nav.dagpenger.opplysning.Opplysning
@@ -32,6 +33,7 @@ class RettighetsperiodePlugin(
     private val overskrivingsStrategi: PeriodeOverskrivingsStrategi = PeriodeOverskrivingsStrategi.BEHOLD_EKSISTERENDE,
 ) : ProsessPlugin {
     override fun regelkjøringFerdig(kontekst: Prosesskontekst) {
+        kontekst.kontekst(this)
         val opplysninger = kontekst.opplysninger
         val egne = opplysninger.kunEgne
 
@@ -50,12 +52,14 @@ class RettighetsperiodePlugin(
                 .somListe()
                 .filter { it.opplysningstype in vilkår }
                 .filterIsInstance<Opplysning<Boolean>>()
-
-        logger.info {
+        val melding =
             """RettighetsperiodePlugin beregner rettighetsperiode basert på i
             |vilkår(${vilkår.size}): $vilkår 
             |utfall(${utfall.size}): $utfall
             """.trimMargin()
+        kontekst.info(melding)
+        logger.info {
+            melding
         }
 
         // Fjern gamle perioder før vi legger til nye
@@ -91,6 +95,11 @@ class RettighetsperiodePlugin(
                 )
             }
     }
+
+    override fun toSpesifikkKontekst() =
+        SpesifikkKontekst(
+            "RettighetsperiodePlugin",
+        )
 
     companion object {
         private val logger = KotlinLogging.logger {}

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/TaptArbeidstidStans.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/TaptArbeidstidStans.kt
@@ -1,4 +1,5 @@
 package no.nav.dagpenger.regel.prosess
+import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
 import no.nav.dagpenger.opplysning.ProsessPlugin
@@ -17,6 +18,7 @@ import no.nav.dagpenger.regel.regelsett.vilkår.TapAvArbeidsinntektOgArbeidstid
  */
 class TaptArbeidstidStans : ProsessPlugin {
     override fun regelkjøringFerdig(kontekst: Prosesskontekst) {
+        kontekst.kontekst(this)
         val opplysninger = kontekst.opplysninger
 
         val påfølgendeUtenTapt =
@@ -36,6 +38,10 @@ class TaptArbeidstidStans : ProsessPlugin {
                 return
             }
 
+            kontekst.info(
+                "Bruker har ikke oppfylt kravet til tapt arbeidstid i ${påfølgendeUtenTapt.size} påfølgende perioder. Stans av dagpenger fra og med $stansFraOgMed.",
+            )
+
             opplysninger.leggTil(
                 Faktum(TapAvArbeidsinntektOgArbeidstid.kravTilTaptArbeidstid, false, stansperiode),
             )
@@ -43,4 +49,6 @@ class TaptArbeidstidStans : ProsessPlugin {
             kontekst.beOmRekjøring()
         }
     }
+
+    override fun toSpesifikkKontekst() = SpesifikkKontekst("TaptArbeidstidStans")
 }

--- a/dagpenger/src/test/kotlin/no/nav/dagpenger/features/BeregningSteg.kt
+++ b/dagpenger/src/test/kotlin/no/nav/dagpenger/features/BeregningSteg.kt
@@ -30,7 +30,6 @@ import no.nav.dagpenger.regel.regelsett.fastsetting.Egenandel.egenandel
 import no.nav.dagpenger.regel.regelsett.fastsetting.Vanligarbeidstid.fastsattVanligArbeidstid
 import no.nav.dagpenger.regel.regelsett.vilkår.KravPåDagpenger.harLøpendeRett
 import no.nav.dagpenger.regel.regelsett.vilkår.TapAvArbeidsinntektOgArbeidstid.kravTilArbeidstidsreduksjon
-import no.nav.dagpenger.regel.regelsett.vilkår.Utdanning
 import no.nav.dagpenger.uuid.UUIDv7
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/modell/src/main/kotlin/no/nav/dagpenger/modell/Behandling.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/modell/Behandling.kt
@@ -463,7 +463,9 @@ class Behandling private constructor(
             hendelse.info("Mottatt ${hendelse.type} og startet behandling")
             behandling.emitOpprettet()
 
-            behandling.forretningsprosess.kjørUnderOpprettelse(Prosesskontekst(behandling.opplysninger))
+            behandling.forretningsprosess.kjørUnderOpprettelse(
+                Prosesskontekst(behandling.opplysninger, behandling.behandler),
+            )
 
             behandling.tilstand(UnderBehandling(), hendelse)
         }
@@ -1053,10 +1055,13 @@ class Behandling private constructor(
         avklaringer.avklaringer().forEach { avklaring ->
             val varAktivFør = avklaringerFør[avklaring.id]
             when {
-                varAktivFør == null && avklaring.måAvklares() ->
+                varAktivFør == null && avklaring.måAvklares() -> {
                     hendelse.info("Avklaring opprettet: ${avklaring.kode.kode}")
-                varAktivFør == true && avklaring.erAvbrutt() ->
+                }
+
+                varAktivFør == true && avklaring.erAvbrutt() -> {
                     hendelse.info("Avklaringen er ikke lenger relevant: ${avklaring.kode.kode}")
+                }
             }
         }
         if (rapport.informasjonsbehov.isNotEmpty()) {
@@ -1067,7 +1072,8 @@ class Behandling private constructor(
         hendelse.lagBehov(rapport.informasjonsbehov)
 
         // 2. Kjører plugins via Kontekst
-        val kontekst = Prosesskontekst(opplysninger)
+        val kontekst =
+            Prosesskontekst(opplysninger, behandler)
         forretningsprosess.kjørEtterRegelkjøring(kontekst)
 
         if (rapport.erFerdig()) {

--- a/opplysninger/build.gradle.kts
+++ b/opplysninger/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api("org.javamoney:moneta:1.4.4")
     api("no.nav.dagpenger:dp-grunnbelop:20260109.219.701e55")
     api(libs.kotlin.logging)
+    api("no.nav.dagpenger:aktivitetslogg:20251016.40.a3c526")
 
     testImplementation("org.junit.jupiter:junit-jupiter-params:${libs.versions.junit.get()}")
     testImplementation(libs.kotest.assertions.core)

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Forretningsprosess.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Forretningsprosess.kt
@@ -1,5 +1,9 @@
 package no.nav.dagpenger.opplysning
 
+import no.nav.dagpenger.aktivitetslogg.Aktivitetskontekst
+import no.nav.dagpenger.aktivitetslogg.Aktivitetslogg
+import no.nav.dagpenger.aktivitetslogg.IAktivitetslogg
+import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.regel.Regel
 import java.time.LocalDate
 
@@ -46,7 +50,7 @@ abstract class Forretningsprosess(
             .associateBy { it.produserer }
 }
 
-interface ProsessPlugin {
+interface ProsessPlugin : Aktivitetskontekst {
     fun underOpprettelse(kontekst: Prosesskontekst) {}
 
     fun etterRegelkjøring(kontekst: Prosesskontekst) {}
@@ -56,13 +60,24 @@ interface ProsessPlugin {
 
 data class Prosesskontekst(
     val opplysninger: Opplysninger,
-) {
+    private val aktivitetslogg: IAktivitetslogg = Aktivitetslogg(),
+) : Aktivitetskontekst,
+    IAktivitetslogg by aktivitetslogg {
+    init {
+        aktivitetslogg.kontekst(this)
+    }
+
     var kreverRekjøring: Boolean = false
         private set
 
     fun beOmRekjøring() {
         kreverRekjøring = true
     }
+
+    override fun toSpesifikkKontekst(): SpesifikkKontekst =
+        SpesifikkKontekst(
+            "Prosesskontekst",
+        )
 }
 
 class Prosessregister {

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/verdier/Periode.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/verdier/Periode.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.opplysning.verdier
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 data class Periode(
     override val start: LocalDate,
@@ -23,4 +24,10 @@ data class Periode(
 
             override fun next(): LocalDate = current.apply { current = current.plusDays(1) }
         }
+
+    override fun toString() = "${start.format(datoFormatterer)} til ${endInclusive.format(datoFormatterer)}"
+
+    private companion object {
+        val datoFormatterer = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+    }
 }


### PR DESCRIPTION
…m skjer inne i plugins ut i aktivitetsloggen

- injiserer IAktivitetslogg i Prosesskontekontekst fra Behandling.behandler
- gjør ProsessPlugin til Aktivitetskontekst og setter plugin-kontekst ved logging
 - legger til info-logging i beregnings-/omgjøringsflyt
 - forbedrer Periode.toString() for lesbare loggmeldinger