### PR TITLE
Sørg for at vi sjekker arbeidssøkerregistreringstatus etter en stans …

### DIFF
--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/Avklaringspunkter.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/Avklaringspunkter.kt
@@ -128,8 +128,9 @@ object Avklaringspunkter {
     val SøktGjenopptak =
         Avklaringkode(
             kode = "SøktGjenopptak",
-            tittel = "Søkt gjenopptak",
-            beskrivelse = "Søker har søkt om gjenopptak. Saker som skal gjenopptas må håndteres i Arena.",
+            tittel = "Søkt gjenopptak, men har ikke noe historikk å ta utgangspunkt i.",
+            beskrivelse = "Søker har søkt om gjenopptak.",
+            kanAvbrytes = false,
         )
 
     val MuligGjenopptak =
@@ -142,8 +143,9 @@ object Avklaringspunkter {
     val GjenopptakBehandling =
         Avklaringkode(
             kode = "GjenopptakBehandling",
-            tittel = "!! Behandles som gjenopptak i ny løsning. Disse støtter vi ikke, så IKKE RØR 😬",
-            beskrivelse = "Denne saken har en innvilget behandling i ny løsning. og det må vurderes om den skal gjenopptas.",
+            tittel = "Behandles som gjenopptak i ny løsning",
+            beskrivelse = "Denne saken har en innvilget behandling og det må vurderes om retten skal gjenopptas.",
+            kanAvbrytes = false,
         )
 
     val InntektNesteKalendermåned =

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/AvsluttetArbeidssøkerperiodeHendelse.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/hendelse/AvsluttetArbeidssøkerperiodeHendelse.kt
@@ -14,6 +14,7 @@ import no.nav.dagpenger.opplysning.Gyldighetsperiode
 import no.nav.dagpenger.opplysning.Opplysninger
 import no.nav.dagpenger.opplysning.Systemkilde
 import no.nav.dagpenger.opplysning.TemporalCollection
+import no.nav.dagpenger.opplysning.Utledning
 import no.nav.dagpenger.regel.prosess.Stansprosess
 import no.nav.dagpenger.regel.regelsett.vilkår.KravPåDagpenger.harLøpendeRett
 import no.nav.dagpenger.regel.regelsett.vilkår.Meldeplikt.oppfyllerMeldeplikt
@@ -57,19 +58,12 @@ class AvsluttetArbeidssøkerperiodeHendelse(
             return StartHendelseResultat.OppdaterBehandling("Fant ingen behandling å kjede på")
         }
 
+        val hendelseTypeOpplysning = Faktum(hendelseTypeOpplysningstype, type, Gyldighetsperiode.kun(skjedde), kilde = kilde)
         return Opprettet(
             Behandling(
                 basertPå = forrigeBehandling,
                 behandler = this,
-                opplysninger =
-                    listOf(
-                        Faktum(
-                            hendelseTypeOpplysningstype,
-                            type,
-                            Gyldighetsperiode.kun(skjedde),
-                            kilde = kilde,
-                        ),
-                    ),
+                opplysninger = listOf(hendelseTypeOpplysning),
                 avklaringer =
                     buildList {
                         if (avsluttetArbeidssøkerperiode.manueltAvregistrert) {
@@ -117,6 +111,7 @@ class AvsluttetArbeidssøkerperiodeHendelse(
                         false,
                         Gyldighetsperiode(fraOgMed = avsluttetArbeidssøkerperiode.avsluttetTidspunkt.toLocalDate()),
                         kilde = kilde,
+                        utledetAv = Utledning(this::class.java.simpleName, listOf(hendelseTypeOpplysning)),
                     ),
                 )
 

--- a/docs/avklaringer.approved.md
+++ b/docs/avklaringer.approved.md
@@ -89,12 +89,12 @@ Sjekk om søker har andre fulle ytelser. <br>Om søker har andre fulle ytelser, 
 - Medlem har reduserte ytelser fra folketrygden (Samordning)
 
 ---
-## !! Behandles som gjenopptak i ny løsning. Disse støtter vi ikke, så IKKE RØR 😬
+## Behandles som gjenopptak i ny løsning
 - **Kode:** `GjenopptakBehandling`
 - **Kan lukkes av saksbehandler:** ✅ 
-- **Lukkes automatisk når opplysningene endres:** ✅ 
+- **Lukkes automatisk når opplysningene endres:** ❌ 
 ### Beskrivelse
-Denne saken har en innvilget behandling i ny løsning. og det må vurderes om den skal gjenopptas.
+Denne saken har en innvilget behandling og det må vurderes om retten skal gjenopptas.
 
 ---
 ## Permittering
@@ -326,12 +326,12 @@ Søker har fått utbetalt sykepenger. Sjekk om sykepengene er svangerskapsrelate
 Søknadstidspunktet ligger mer enn 14 dager fram i tid.
 
 ---
-## Søkt gjenopptak
+## Søkt gjenopptak, men har ikke noe historikk å ta utgangspunkt i.
 - **Kode:** `SøktGjenopptak`
 - **Kan lukkes av saksbehandler:** ✅ 
-- **Lukkes automatisk når opplysningene endres:** ✅ 
+- **Lukkes automatisk når opplysningene endres:** ❌ 
 ### Beskrivelse
-Søker har søkt om gjenopptak. Saker som skal gjenopptas må håndteres i Arena.
+Søker har søkt om gjenopptak.
 
 ---
 ## Du må velge kun én beregningsregel for tap av arbeidsinntekt og arbeidstid

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/mottak/MeldekortBehandlingsresultatKontrollregningMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/mottak/MeldekortBehandlingsresultatKontrollregningMottakTest.kt
@@ -3,12 +3,10 @@ package no.nav.dagpenger.mediator.mottak
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
-import no.nav.dagpenger.regel.OpplysningsTyper.OppfyllerMeldepliktId
 import no.nav.dagpenger.regel.OpplysningsTyper.arbeidsdagId
 import no.nav.dagpenger.regel.OpplysningsTyper.arbeidstimerId
 import no.nav.dagpenger.regel.OpplysningsTyper.maksimalVanligArbeidstidId
 import no.nav.dagpenger.regel.OpplysningsTyper.trekkVedForsenMeldingId
-import no.nav.dagpenger.regelverk.HendelseTypeId
 import org.junit.jupiter.api.Test
 import java.util.UUID
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/scenario/ScenarioTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/scenario/ScenarioTest.kt
@@ -3,6 +3,7 @@ package no.nav.dagpenger.scenario
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldHaveAtMostSize
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
@@ -757,6 +758,45 @@ class ScenarioTest {
             behandlingsresultatForslag {
                 rettighetsperioder.size shouldBe 1
                 rettighetsperioder.first().fraOgMed shouldBe 15.mai(2026)
+            }
+        }
+    }
+
+    @Test
+    fun `tester stans og gjenopptak på samme dag`() {
+        nyttScenario {
+            inntektSiste12Mnd = 500000
+        }.test {
+            person.søkDagpenger(21.juni(2018))
+
+            behovsløsere.løsTilForslag()
+            saksbehandler.lukkAlleAvklaringer()
+            saksbehandler.godkjenn()
+            saksbehandler.beslutt()
+
+            behandlingsresultat(1) {
+                rettighetsperioder shouldHaveSize 1
+            }
+
+            person.avsluttArbeidssøkerperiode(22.juni(2018), 22.juni(2018).atTime(14, 2))
+            saksbehandler.lukkAlleAvklaringer()
+            saksbehandler.godkjenn()
+
+            behandlingsresultat(2) {
+                rettighetsperioder shouldHaveSize 2
+            }
+
+            person.søkGjenopptak(22.juni(2018))
+            behovsløsere.løsTilForslag()
+
+            saksbehandler.åpneAvklaringer().map { it.kode } shouldContainAll listOf("GjenopptakBehandling")
+
+            behandlingsresultatForslag(5) {
+                rettighetsperioder shouldHaveSize 2
+                rettighetsperioder.last().harRett shouldBe true
+
+                // TODO: Fordi de to siste rettighetsperiodene ligger "oppå" hverandre blir ikke dette riktig
+                // førteTil shouldBe "Gjenopptak"
             }
         }
     }

--- a/mediator/src/test/resources/no/nav/dagpenger/scenario/ScenarioTest.tester stans og gjenopptak på samme dag.approved.txt
+++ b/mediator/src/test/resources/no/nav/dagpenger/scenario/ScenarioTest.tester stans og gjenopptak på samme dag.approved.txt
@@ -1,0 +1,84 @@
+Laget avklaring om HarTilleggsopplysninger
+Opprettet ny behandling
+Behandling endret tilstand til: UnderBehandling
+Behov:
+- Fødselsdato
+- ØnskerDagpengerFraDato
+Laget avklaring om HattLukkedeSakerSiste8Uker
+Laget avklaring om MuligGjenopptak
+Behov:
+- HelseTilAlleTyperJobb
+- Inntekt
+- KanJobbeDeltid
+- KanJobbeHvorSomHelst
+- Lønnsgaranti
+- Ordinær
+- Permittert
+- PermittertFiskeforedling
+- RegistrertSomArbeidssøker
+- Verneplikt
+- VilligTilÅBytteYrke
+- ØnsketArbeidstid
+Laget avklaring om EØSArbeid
+Laget avklaring om InntektNesteKalendermåned
+Laget avklaring om JobbetUtenforNorge
+Behov:
+- AndreØkonomiskeYtelser
+- BostedslandErNorge
+- ErUtestengt
+- Foreldrepenger
+- Omsorgspenger
+- Opplæringspenger
+- Pleiepenger
+- Svangerskapspenger
+- Sykepenger
+- TarUtdanningEllerOpplæring
+- Uføre
+Laget avklaring om SjekkPrøvingsdato
+Laget avklaring om BeregnetArbeidstid
+Behov:
+- BarnetilleggV2
+- OppgittAndreYtelserUtenforNav
+Laget avklaring om BarnMåGodkjennes
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: TilGodkjenning
+Behandling endret tilstand til: TilBeslutning
+Behandling endret tilstand til: Ferdig
+Laget avklaring om UtmeldtArbeidssøker
+Opprettet ny behandling
+Behandling endret tilstand til: UnderBehandling
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: TilGodkjenning
+Behandling endret tilstand til: Ferdig
+Laget avklaring om GjenopptakBehandling
+Laget avklaring om HarTilleggsopplysninger
+Opprettet ny behandling
+Behandling endret tilstand til: UnderBehandling
+Behov:
+- AndreØkonomiskeYtelser
+- BostedslandErNorge
+- HelseTilAlleTyperJobb
+- KanJobbeDeltid
+- KanJobbeHvorSomHelst
+- Lønnsgaranti
+- Ordinær
+- Permittert
+- PermittertFiskeforedling
+- RegistrertSomArbeidssøker
+- TarUtdanningEllerOpplæring
+- Verneplikt
+- VilligTilÅBytteYrke
+- ØnskerDagpengerFraDato
+- ØnsketArbeidstid
+Laget avklaring om HattLukkedeSakerSiste8Uker
+Laget avklaring om MuligGjenopptak
+Behov:
+- ErUtestengt
+- Foreldrepenger
+- Omsorgspenger
+- Opplæringspenger
+- Pleiepenger
+- Svangerskapspenger
+- Sykepenger
+- Uføre
+Behandling endret tilstand til: ForslagTilVedtak


### PR DESCRIPTION
…forårsaket av utmelding i arbeidssøkerregisteret.

Vi har en kjede fra `registrert som arbeidssøker` -> `søknadstidspunkt` -> `søknad`. Når søknad om gjenopptak kommer så endres `søknad`, som fører til at `søknadstidspunkt` endres, som fører til at vi innhenter `registrert som arbeidssøker` på nytt.

Dette har fungert fint i tidligere tester av gjenopptak.

Men etter vi innførte automatisk stans ved utmelding av arbeidssøkerregisteret så setter vi direkte inn en opplysning om at bruker ikke lenger er `registrert som arbeidssøker` – uten at den kobles til `søknad`.

Dermed blir den ikke innhentet på nytt når søknaden om gjenopptaket kommer.

Å koble den nye opplysningen om registrert til hendelseType fungerer fordi en søknad overskriver samme opplysningstype.