### PR TITLE
Støtte for person med flere identer (merge/split)

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/BehandlingRuntime.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/BehandlingRuntime.kt
@@ -5,6 +5,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.ktor.server.application.Application
 import no.nav.dagpenger.mediator.api.auth.AuthFactory
 import no.nav.dagpenger.mediator.api.behandlingApi
+import no.nav.dagpenger.mediator.api.personAdminApi
 import no.nav.dagpenger.mediator.audit.Auditlogg
 import no.nav.dagpenger.mediator.db.DatabaseSession
 import no.nav.dagpenger.mediator.meldekort.MeldekortBehandlingskø
@@ -137,6 +138,7 @@ class BehandlingRuntime(
             messageContext = messageContextFactory,
             oppdateringRepository = oppdateringRepository,
         )
+        personAdminApi(personRepository)
     }
 
     fun meldekortBehandlingskø(messageContext: MessageContext) =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/api/PersonAdminApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/api/PersonAdminApi.kt
@@ -1,0 +1,63 @@
+package no.nav.dagpenger.mediator.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.auth.authenticate
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import no.nav.dagpenger.mediator.repository.PersonRepository
+import no.nav.dagpenger.modell.Ident
+
+internal fun Application.personAdminApi(personRepository: PersonRepository) {
+    routing {
+        authenticate("admin") {
+            route("person/merge") {
+                post {
+                    val request = call.receive<MergePersonRequest>()
+                    personRepository.merge(
+                        winner = parseIdent(request.winnerIdent),
+                        loser = parseIdent(request.loserIdent),
+                    )
+                    call.respond(HttpStatusCode.OK, MergePersonResponse())
+                }
+            }
+            route("person/split") {
+                post {
+                    val request = call.receive<SplitPersonRequest>()
+                    personRepository.split(
+                        loserIdent = parseIdent(request.loserIdent),
+                        fraIdent = parseIdent(request.fraIdent),
+                    )
+                    call.respond(HttpStatusCode.OK, SplitPersonResponse())
+                }
+            }
+        }
+    }
+}
+
+private fun parseIdent(ident: String): Ident =
+    runCatching { Ident(ident) }.getOrElse {
+        throw BadRequestException("Ugyldig ident – må være 11 siffer")
+    }
+
+internal data class MergePersonRequest(
+    val winnerIdent: String,
+    val loserIdent: String,
+)
+
+internal data class MergePersonResponse(
+    val melding: String = "Merge fullført",
+)
+
+internal data class SplitPersonRequest(
+    val loserIdent: String,
+    val fraIdent: String,
+)
+
+internal data class SplitPersonResponse(
+    val melding: String = "Split fullført",
+)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/repository/PersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/repository/PersonRepository.kt
@@ -124,6 +124,18 @@ interface PersonRepository : BehandlingRepository {
     @WithSpan
     fun harIdent(ident: Ident): Boolean
 
+    @WithSpan
+    fun merge(
+        winner: Ident,
+        loser: Ident,
+    )
+
+    @WithSpan
+    fun split(
+        loserIdent: Ident,
+        fraIdent: Ident,
+    )
+
     private fun medSpan(
         string: String,
         block: () -> Unit,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/repository/PersonRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/repository/PersonRepositoryPostgres.kt
@@ -1,6 +1,8 @@
 package no.nav.dagpenger.mediator.repository
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.NotFoundException
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.prometheus.metrics.model.snapshots.Labels
 import kotliquery.Session
@@ -15,6 +17,7 @@ import no.nav.dagpenger.modell.Rettighetstatus
 import no.nav.dagpenger.modell.Utestengningsperiode
 import no.nav.dagpenger.opplysning.TemporalCollection
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 
@@ -36,11 +39,21 @@ class PersonRepositoryPostgres(
                     queryOf(
                         //language=PostgreSQL
                         """
-                        SELECT * FROM person WHERE ident = :ident FOR UPDATE
+                        SELECT p.ident, (
+                            SELECT array_agg(pi_all.ident)
+                            FROM person_ident pi_all
+                            WHERE pi_all.person_id = p.person_id
+                        ) AS alle_identer
+                        FROM person p
+                        INNER JOIN person_ident pi ON pi.ident = :ident AND pi.person_id = p.person_id
+                        FOR UPDATE OF p
                         """.trimIndent(),
                         mapOf("ident" to ident.identifikator()),
                     ).map { row ->
-                        val dbIdent = Ident(row.string("ident"))
+                        val kanoniskIdent = row.string("ident")
+                        val alleIdenter = row.array<String>("alle_identer").toList()
+                        val aliaser = alleIdenter.filter { it != kanoniskIdent }
+                        val dbIdent = Ident(kanoniskIdent, aliaser)
                         val rettighetstatuser = session.rettighetstatusFor(dbIdent)
                         val utestengninger = session.utestengningerFor(dbIdent)
                         val behandlinger = behandlingRepository.hentBehandlinger(dbIdent)
@@ -78,8 +91,14 @@ class PersonRepositoryPostgres(
                 queryOf(
                     //language=PostgreSQL
                     """
-                    SELECT 1 FROM utestengning
-                    WHERE ident = :ident AND fra_og_med <= :dato AND til_og_med >= :dato
+                    SELECT 1 FROM utestengning u
+                    WHERE u.ident = ANY(
+                        SELECT pi.ident FROM person_ident pi
+                        WHERE pi.person_id = (
+                            SELECT pi2.person_id FROM person_ident pi2 WHERE pi2.ident = :ident
+                        )
+                    )
+                    AND u.fra_og_med <= :dato AND u.til_og_med >= :dato
                     LIMIT 1
                     """.trimIndent(),
                     mapOf("ident" to ident.identifikator(), "dato" to dato),
@@ -95,12 +114,213 @@ class PersonRepositoryPostgres(
                     queryOf(
                         //language=PostgreSQL
                         """
-                        SELECT 1 FROM person WHERE ident = :ident
+                        SELECT 1 FROM person_ident WHERE ident = :ident
                         """.trimIndent(),
                         mapOf("ident" to ident.identifikator()),
                     ).map { row -> row.intOrNull(1) ?: 0 }.asSingle,
                 ) == 1
         }
+
+    @WithSpan
+    override fun merge(
+        winner: Ident,
+        loser: Ident,
+    ) {
+        dbSession.transaction {
+            val winnerPersonId = session.finnPersonId(winner) ?: throw NotFoundException("Vinner-ident finnes ikke")
+            val loserPersonId = session.finnPersonId(loser) ?: throw NotFoundException("Taper-ident finnes ikke")
+            if (winnerPersonId == loserPersonId) {
+                logger.info { "Merge no-op: $winnerPersonId og $loserPersonId peker allerede på samme person" }
+                return@transaction
+            }
+
+            val winnerIdent = session.finnKanoniskIdent(winnerPersonId)
+            val loserIdenter = session.finnAlleIdenter(loserPersonId)
+
+            logger.info { "Merger person $loserPersonId inn i $winnerPersonId" }
+
+            // Flytt alle loser-identer til winner sin person_id
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    "UPDATE person_ident SET person_id = :winner, er_gjeldende = FALSE WHERE person_id = :loser",
+                    mapOf("winner" to winnerPersonId, "loser" to loserPersonId),
+                ).asUpdate,
+            )
+
+            // Flytt alle FK-koblinger fra loser-identer til winner-identen
+            loserIdenter.forEach { loserIdentStr ->
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        """
+                        INSERT INTO person_behandling (ident, behandling_id)
+                        SELECT :winner, behandling_id FROM person_behandling WHERE ident = :loser
+                        ON CONFLICT DO NOTHING
+                        """.trimIndent(),
+                        mapOf("winner" to winnerIdent, "loser" to loserIdentStr),
+                    ).asUpdate,
+                )
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        "DELETE FROM person_behandling WHERE ident = :loser",
+                        mapOf("loser" to loserIdentStr),
+                    ).asUpdate,
+                )
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        "UPDATE rettighetstatus SET ident = :winner WHERE ident = :loser",
+                        mapOf("winner" to winnerIdent, "loser" to loserIdentStr),
+                    ).asUpdate,
+                )
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        "UPDATE utestengning SET ident = :winner WHERE ident = :loser",
+                        mapOf("winner" to winnerIdent, "loser" to loserIdentStr),
+                    ).asUpdate,
+                )
+            }
+
+            // Beholder loser sin person-rad som anker for FK-integritet (meldekort_hendelse etc.)
+            // Loser-raden er ikke lenger nåbar via person_ident (alle peker til winner)
+        }
+    }
+
+    @WithSpan
+    override fun split(
+        loserIdent: Ident,
+        fraIdent: Ident,
+    ) {
+        dbSession.transaction {
+            val fraPersonId = session.finnPersonId(fraIdent) ?: throw NotFoundException("Fra-ident finnes ikke")
+            val loserPersonId = session.finnPersonId(loserIdent) ?: throw NotFoundException("Loser-ident finnes ikke")
+            if (loserPersonId != fraPersonId) {
+                throw BadRequestException("Loser-ident tilhører ikke fra-personen — er de allerede splittet?")
+            }
+            val fraKanoniskIdent = session.finnKanoniskIdent(fraPersonId)
+
+            // Finn behandlinger initiert av loserIdent (provenance via behandler_hendelse)
+            val loserBehandlingIds =
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        """
+                        SELECT DISTINCT pb.behandling_id
+                        FROM person_behandling pb
+                        INNER JOIN behandler_hendelse_behandling bhb ON bhb.behandling_id = pb.behandling_id
+                        INNER JOIN behandler_hendelse bh ON bh.melding_id = bhb.melding_id
+                        WHERE bh.ident = :loserIdent AND pb.ident = :fraIdent
+                        """.trimIndent(),
+                        mapOf("loserIdent" to loserIdent.identifikator(), "fraIdent" to fraKanoniskIdent),
+                    ).map { row -> row.uuid("behandling_id") }.asList,
+                )
+
+            logger.info { "Splitter loser fra person $fraPersonId med ${loserBehandlingIds.size} behandlinger" }
+
+            // Opprett ny person-rad for loser-identen (kan allerede eksistere fra før merge)
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    "INSERT INTO person (ident) VALUES (:ident) ON CONFLICT (ident) DO NOTHING",
+                    mapOf("ident" to loserIdent.identifikator()),
+                ).asUpdate,
+            )
+            // Les person_id direkte fra person-tabellen — person_ident peker fortsatt til winner
+            val nyPersonId =
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        "SELECT person_id FROM person WHERE ident = :ident",
+                        mapOf("ident" to loserIdent.identifikator()),
+                    ).map { row -> row.uuid("person_id") }.asSingle,
+                ) ?: error("Kunne ikke opprette person for loser-ident")
+
+            // Flytt loser-identen til sin nye person_id
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    "UPDATE person_ident SET person_id = :nyPersonId, er_gjeldende = TRUE WHERE ident = :ident",
+                    mapOf("nyPersonId" to nyPersonId, "ident" to loserIdent.identifikator()),
+                ).asUpdate,
+            )
+
+            if (loserBehandlingIds.isNotEmpty()) {
+                val behandlingsArray = loserBehandlingIds.toTypedArray()
+
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        """
+                        INSERT INTO person_behandling (ident, behandling_id)
+                        SELECT :loser, behandling_id FROM person_behandling
+                        WHERE ident = :fra AND behandling_id = ANY(:behandlinger)
+                        ON CONFLICT DO NOTHING
+                        """.trimIndent(),
+                        mapOf("loser" to loserIdent.identifikator(), "fra" to fraKanoniskIdent, "behandlinger" to behandlingsArray),
+                    ).asUpdate,
+                )
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        "DELETE FROM person_behandling WHERE ident = :fra AND behandling_id = ANY(:behandlinger)",
+                        mapOf("fra" to fraKanoniskIdent, "behandlinger" to behandlingsArray),
+                    ).asUpdate,
+                )
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        "UPDATE rettighetstatus SET ident = :loser WHERE ident = :fra AND behandling_id = ANY(:behandlinger)",
+                        mapOf("loser" to loserIdent.identifikator(), "fra" to fraKanoniskIdent, "behandlinger" to behandlingsArray),
+                    ).asUpdate,
+                )
+                session.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        "UPDATE utestengning SET ident = :loser WHERE ident = :fra AND behandling_id = ANY(:behandlinger)",
+                        mapOf("loser" to loserIdent.identifikator(), "fra" to fraKanoniskIdent, "behandlinger" to behandlingsArray),
+                    ).asUpdate,
+                )
+            }
+        }
+    }
+
+    private fun Session.finnPersonId(ident: Ident): UUID? =
+        run(
+            queryOf(
+                //language=PostgreSQL
+                "SELECT person_id FROM person_ident WHERE ident = :ident",
+                mapOf("ident" to ident.identifikator()),
+            ).map { it.uuid("person_id") }.asSingle,
+        )
+
+    private fun Session.finnKanoniskIdent(personId: UUID): String =
+        run(
+            queryOf(
+                //language=PostgreSQL
+                "SELECT ident FROM person WHERE person_id = :personId",
+                mapOf("personId" to personId),
+            ).map { it.string("ident") }.asSingle,
+        ) ?: error("Fant ingen kanonisk ident for person_id $personId")
+
+    private fun Session.finnAlleIdenter(personId: UUID): List<String> =
+        run(
+            queryOf(
+                //language=PostgreSQL
+                "SELECT ident FROM person_ident WHERE person_id = :personId",
+                mapOf("personId" to personId),
+            ).map { it.string("ident") }.asList,
+        )
+
+    // Private hjelpere for aliasoppslag
+    //
+    // Disse kalles alltid fra hent(), der Ident allerede er lastet med alle aliaser fra DB.
+    // De bruker alleIdentifikatorer() direkte — ingen ekstra DB-rundtur.
+    //
+    // Offentlige metoder (erUtestengt, rettighetstatusFor) kan motta en Ident uten aliaser,
+    // og gjør derfor et friskt oppslag via person_ident-subquery.
 
     private fun Session.rettighetstatusFor(ident: Ident): TemporalCollection<Rettighetstatus> =
         this
@@ -108,9 +328,9 @@ class PersonRepositoryPostgres(
                 queryOf(
                     //language=PostgreSQL
                     """
-                    SELECT * FROM rettighetstatus WHERE ident = :ident ORDER BY opprettet
+                    SELECT * FROM rettighetstatus WHERE ident = ANY(:identer) ORDER BY opprettet
                     """.trimIndent(),
-                    mapOf("ident" to ident.identifikator()),
+                    mapOf("identer" to ident.alleIdentifikatorer().toTypedArray()),
                 ).map { row ->
                     val gjelderFra = row.localDate("gjelder_fra")
                     val virkningsdato = row.localDate("virkningsdato")
@@ -131,9 +351,9 @@ class PersonRepositoryPostgres(
                 queryOf(
                     //language=PostgreSQL
                     """
-                    SELECT * FROM utestengning WHERE ident = :ident ORDER BY fra_og_med
+                    SELECT * FROM utestengning WHERE ident = ANY(:identer) ORDER BY fra_og_med
                     """.trimIndent(),
-                    mapOf("ident" to ident.identifikator()),
+                    mapOf("identer" to ident.alleIdentifikatorer().toTypedArray()),
                 ).map { row ->
                     Utestengningsperiode(
                         fraOgMed = row.localDate("fra_og_med"),
@@ -161,6 +381,18 @@ class PersonRepositoryPostgres(
                 //language=PostgreSQL
                 """
                 INSERT INTO person (ident) VALUES (:ident) ON CONFLICT DO NOTHING
+                """.trimIndent(),
+                mapOf("ident" to person.ident.identifikator()),
+            ).asUpdate,
+        )
+        // Sørg for at person_ident-raden finnes for nye personer
+        unitOfWork.session.run(
+            queryOf(
+                //language=PostgreSQL
+                """
+                INSERT INTO person_ident (ident, person_id)
+                SELECT :ident, person_id FROM person WHERE ident = :ident
+                ON CONFLICT DO NOTHING
                 """.trimIndent(),
                 mapOf("ident" to person.ident.identifikator()),
             ).asUpdate,

--- a/mediator/src/main/resources/db/migration/V96__PERSON_IDENT.sql
+++ b/mediator/src/main/resources/db/migration/V96__PERSON_IDENT.sql
@@ -1,0 +1,19 @@
+-- Legg til stabilt UUID-anker på person-tabellen
+ALTER TABLE person ADD COLUMN person_id UUID NOT NULL DEFAULT gen_random_uuid();
+ALTER TABLE person ADD CONSTRAINT person_person_id_unique UNIQUE (person_id);
+
+-- Kobling mellom ident og person: en person kan ha flere identer
+CREATE TABLE person_ident
+(
+    ident        TEXT        NOT NULL PRIMARY KEY,
+    person_id    UUID        NOT NULL REFERENCES person (person_id),
+    er_gjeldende BOOLEAN     NOT NULL DEFAULT TRUE,
+    opprettet    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_person_ident_person_id ON person_ident (person_id);
+
+-- Backfill fra eksisterende person-rader
+INSERT INTO person_ident (ident, person_id, er_gjeldende)
+SELECT ident, person_id, TRUE
+FROM person;

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/InMemoryPersonRepository.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/InMemoryPersonRepository.kt
@@ -103,6 +103,24 @@ class InMemoryPersonRepository :
         TODO("Not yet implemented")
     }
 
+    override fun merge(
+        winner: Ident,
+        loser: Ident,
+    ) {
+        val winnerPerson = persondb[winner] ?: error("Vinner-ident $winner finnes ikke")
+        val loserPerson = persondb[loser] ?: return
+        if (winnerPerson.ident == loserPerson.ident) return
+        // Flytt loser-data til winner ved å fjerne loser fra db (winner beholder sine data)
+        persondb.remove(loser)
+    }
+
+    override fun split(
+        loserIdent: Ident,
+        fraIdent: Ident,
+    ) {
+        TODO("Not yet implemented in InMemoryPersonRepository")
+    }
+
     fun reset() {
         persondb.clear()
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/PostgresMigrationTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/db/PostgresMigrationTest.kt
@@ -8,7 +8,7 @@ class PostgresMigrationTest {
     fun `Migration scripts are applied successfully`() {
         withIsolatedDb {
             val migrations = runMigration()
-            migrations shouldBeExactly 28
+            migrations shouldBeExactly 29
         }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/repository/PersonRepositoryPostgresTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/repository/PersonRepositoryPostgresTest.kt
@@ -89,6 +89,54 @@ class PersonRepositoryPostgresTest {
             personRepositoryPostgres.lagre(person)
         }
 
+    @Test
+    fun `hent finner person via alias-ident etter merge`() =
+        personTest {
+            val vinner = Ident("12345678901")
+            val taper = Ident("10987654321")
+
+            personRepositoryPostgres.lagre(Person(vinner))
+            personRepositoryPostgres.lagre(Person(taper))
+
+            personRepositoryPostgres.merge(winner = vinner, loser = taper)
+
+            val funnetViaVinner = personRepositoryPostgres.hent(vinner)
+            val funnetViaTaper = personRepositoryPostgres.hent(taper)
+
+            // Begge peker på samme kanoniske ident (vinner) etter merge
+            funnetViaVinner?.ident?.identifikator() shouldBe vinner.identifikator()
+            funnetViaTaper?.ident?.identifikator() shouldBe vinner.identifikator()
+            funnetViaVinner?.ident?.alleIdentifikatorer()!! shouldContain taper.identifikator()
+        }
+
+    @Test
+    fun `harIdent returnerer true for både vinner og taper etter merge`() =
+        personTest {
+            val vinner = Ident("12345678901")
+            val taper = Ident("10987654321")
+
+            personRepositoryPostgres.lagre(Person(vinner))
+            personRepositoryPostgres.lagre(Person(taper))
+            personRepositoryPostgres.merge(winner = vinner, loser = taper)
+
+            personRepositoryPostgres.harIdent(vinner) shouldBe true
+            personRepositoryPostgres.harIdent(taper) shouldBe true
+        }
+
+    @Test
+    fun `merge er idempotent`() =
+        personTest {
+            val vinner = Ident("12345678901")
+            val taper = Ident("10987654321")
+
+            personRepositoryPostgres.lagre(Person(vinner))
+            personRepositoryPostgres.lagre(Person(taper))
+            personRepositoryPostgres.merge(winner = vinner, loser = taper)
+            personRepositoryPostgres.merge(winner = vinner, loser = taper)
+
+            personRepositoryPostgres.hent(taper)?.ident?.identifikator() shouldBe vinner.identifikator()
+        }
+
     private fun personTest(block: Persontest.() -> Unit) {
         withMigratedDb {
             val fnr = "12345678901"

--- a/modell/src/main/kotlin/no/nav/dagpenger/modell/Ident.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/modell/Ident.kt
@@ -1,10 +1,12 @@
 package no.nav.dagpenger.modell
 
-data class Ident(
+class Ident(
     private val ident: String,
+    private val aliaser: List<String> = emptyList(),
 ) {
     init {
         require(ident.matches(Regex("[0-9]{11}"))) { "Personident må ha 11 siffer" }
+        require(aliaser.all { it.matches(Regex("[0-9]{11}")) }) { "Alle aliaser må ha 11 siffer" }
     }
 
     companion object {
@@ -13,7 +15,11 @@ data class Ident(
 
     fun identifikator() = ident
 
-    fun alleIdentifikatorer() = listOf(ident)
+    fun alleIdentifikatorer(): List<String> = listOf(ident) + aliaser
+
+    override fun equals(other: Any?) = other is Ident && ident == other.ident
+
+    override fun hashCode() = ident.hashCode()
 
     override fun toString(): String = "Ident(${ident.substring(0, 6)}*****)"
 }


### PR DESCRIPTION
Legger til person_id UUID som stabil nøkkel i person-tabellen, med person_ident som source-of-truth for ident → person-mapping.

- Ny migrering V96: person_id-kolonne og person_ident-tabell
- Ident utvides med aliaser (equals/hashCode på primær-ident)
- PersonRepository: merge(winner, loser) og split(loserIdent, fraIdent)
- PersonAdminApi: POST /person/merge og /person/split (admin-autentisering)
- Alle SQL-oppslag er alias-bevisste via person_ident