### PR TITLE
feat: legg til OpenTelemetry-spans i regelkjøring og hendelseshåndtering

### DIFF
--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/MeldekortBeregningPlugin.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/MeldekortBeregningPlugin.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.regel.prosess
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
@@ -23,6 +24,7 @@ import no.nav.dagpenger.regel.regelsett.beregning.TerskelTrekkForSenMelding
 class MeldekortBeregningPlugin(
     private val kvoter: List<KvoteDefinisjon>,
 ) : ProsessPlugin {
+    @WithSpan("MeldekortBeregningPlugin.regelkjøringFerdig")
     override fun regelkjøringFerdig(kontekst: Prosesskontekst) {
         val opplysninger = kontekst.opplysninger
         val meldeperiode = meldeperiode(opplysninger)

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/Omgjøringsprosess.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/Omgjøringsprosess.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.regel.prosess
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.dagpenger.aktivitetslogg.Aktivitetskontekst
 import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Forretningsprosess
@@ -74,6 +75,7 @@ class OmgjøringBeregningPlugin(
     private val meldekortBeregningPlugin: MeldekortBeregningPlugin,
 ) : ProsessPlugin,
     Aktivitetskontekst {
+    @WithSpan("OmgjøringBeregningPlugin.regelkjøringFerdig")
     override fun regelkjøringFerdig(kontekst: Prosesskontekst) {
         kontekst.kontekst(this)
         val opplysninger = kontekst.opplysninger

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/RettighetsperiodePlugin.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/RettighetsperiodePlugin.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.regel.prosess
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.dagpenger.aktivitetslogg.SpesifikkKontekst
 import no.nav.dagpenger.opplysning.Faktum
 import no.nav.dagpenger.opplysning.Gyldighetsperiode
@@ -35,6 +36,7 @@ class RettighetsperiodePlugin(
     private val overskrivingsStrategi: PeriodeOverskrivingsStrategi = PeriodeOverskrivingsStrategi.BEHOLD_EKSISTERENDE,
     private val slåSammenLike: Boolean = true,
 ) : ProsessPlugin {
+    @WithSpan("RettighetsperiodePlugin.regelkjøringFerdig")
     override fun regelkjøringFerdig(kontekst: Prosesskontekst) {
         kontekst.kontekst(this)
         val opplysninger = kontekst.opplysninger

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/HendelseMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/HendelseMediator.kt
@@ -4,6 +4,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.withLoggingContext
+import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -60,6 +61,7 @@ internal class HendelseMediator(
     private companion object {
         val logger = KotlinLogging.logger { }
         val sikkerlogg = KotlinLogging.logger("tjenestekall.HendelseMediator")
+        val tracer = GlobalOpenTelemetry.getTracer(HendelseMediator::class.java.name)
     }
 
     fun håndter(
@@ -140,9 +142,22 @@ internal class HendelseMediator(
                 person.registrer(oppdateringObserver)
                 person.registrer(flyttSøskenObserver)
                 observatører.forEach { observatør -> person.registrer(observatør) }
-                tidBruktPerHendelse.labelValues(hendelse.javaClass.simpleName).time {
-                    handler(person)
+
+                val hendelsesSpan =
+                    tracer
+                        .spanBuilder("person.håndter.hendelse")
+                        .setAttribute("hendelse", hendelse.javaClass.simpleName)
+                        .startSpan()
+                try {
+                    hendelsesSpan.makeCurrent().use {
+                        tidBruktPerHendelse.labelValues(hendelse.javaClass.simpleName).time {
+                            handler(person)
+                        }
+                    }
+                } finally {
+                    hendelsesSpan.end()
                 }
+
                 hendelseTeller.labelValues(hendelse.javaClass.simpleName).inc()
             }
             ferdigstill(context, personMediator, oppdateringObserver, hendelse)

--- a/opplysninger/build.gradle.kts
+++ b/opplysninger/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
     api("no.nav.dagpenger:dp-grunnbelop:20260109.219.701e55")
     api(libs.kotlin.logging)
     api("no.nav.dagpenger:aktivitetslogg:20251016.40.a3c526")
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.1.0")
+    implementation("io.opentelemetry:opentelemetry-api:1.36.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-params:${libs.versions.junit.get()}")
     testImplementation(libs.kotest.assertions.core)

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Forretningsprosess.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Forretningsprosess.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.opplysning
 
+import io.opentelemetry.api.GlobalOpenTelemetry
 import no.nav.dagpenger.aktivitetslogg.Aktivitetskontekst
 import no.nav.dagpenger.aktivitetslogg.Aktivitetslogg
 import no.nav.dagpenger.aktivitetslogg.IAktivitetslogg
@@ -33,11 +34,14 @@ abstract class Forretningsprosess(
 
     fun registrer(handler: ProsessPlugin) = plugins.add(handler)
 
-    fun kjørUnderOpprettelse(kontekst: Prosesskontekst) = plugins.forEach { it.underOpprettelse(kontekst) }
+    fun kjørUnderOpprettelse(kontekst: Prosesskontekst) =
+        medSpan("forretningsprosess.kjørUnderOpprettelse", navn) { plugins.forEach { it.underOpprettelse(kontekst) } }
 
-    fun kjørEtterRegelkjøring(kontekst: Prosesskontekst) = plugins.forEach { it.etterRegelkjøring(kontekst) }
+    fun kjørEtterRegelkjøring(kontekst: Prosesskontekst) =
+        medSpan("forretningsprosess.kjørEtterRegelkjøring", navn) { plugins.forEach { it.etterRegelkjøring(kontekst) } }
 
-    fun kjørRegelkjøringFerdig(kontekst: Prosesskontekst) = plugins.forEach { it.regelkjøringFerdig(kontekst) }
+    fun kjørRegelkjøringFerdig(kontekst: Prosesskontekst) =
+        medSpan("forretningsprosess.kjørRegelkjøringFerdig", navn) { plugins.forEach { it.regelkjøringFerdig(kontekst) } }
 
     open fun produsenter(
         regelverksdato: LocalDate,
@@ -48,6 +52,23 @@ abstract class Forretningsprosess(
             .filter { it.skalRevurderes(opplysningerPåPrøvingsdato) }
             .flatMap { it.regler(regelverksdato) }
             .associateBy { it.produserer }
+
+    private companion object {
+        private val tracer = GlobalOpenTelemetry.getTracer(Forretningsprosess::class.java.name)
+
+        private fun medSpan(
+            spanNavn: String,
+            prosessNavn: String,
+            block: () -> Unit,
+        ) {
+            val span = tracer.spanBuilder(spanNavn).setAttribute("prosess", prosessNavn).startSpan()
+            try {
+                span.makeCurrent().use { block() }
+            } finally {
+                span.end()
+            }
+        }
+    }
 }
 
 interface ProsessPlugin : Aktivitetskontekst {

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Regelkjøring.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Regelkjøring.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.opplysning
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.opentelemetry.api.GlobalOpenTelemetry
 import no.nav.dagpenger.opplysning.Regelkjøring.Regelkjøringstilstand.Companion.aktiver
 import no.nav.dagpenger.opplysning.regel.Ekstern
 import no.nav.dagpenger.opplysning.regel.Regel
@@ -85,6 +86,24 @@ class Regelkjøring(
 
     companion object {
         private val logger = KotlinLogging.logger { }
+        private val tracer = GlobalOpenTelemetry.getTracer(Regelkjøring::class.java.name)
+
+        private fun <T> medSpan(
+            navn: String,
+            attributter: Map<String, String> = emptyMap(),
+            block: (io.opentelemetry.api.trace.Span) -> T,
+        ): T {
+            val span =
+                tracer
+                    .spanBuilder(navn)
+                    .apply { attributter.forEach { (k, v) -> setAttribute(k, v) } }
+                    .startSpan()
+            return try {
+                span.makeCurrent().use { block(span) }
+            } finally {
+                span.end()
+            }
+        }
     }
 
     private val observatører: MutableSet<RegelkjøringObserver> = mutableSetOf()
@@ -106,72 +125,77 @@ class Regelkjøring(
         observatører.add(observer)
     }
 
-    fun evaluer(): Regelkjøringsrapport {
-        var totalRapport: Regelkjøringsrapport? = null
-        for (dato in prøvingsperiode) {
-            val rapport = evaluerDag(dato)
-            totalRapport = totalRapport?.plus(rapport) ?: rapport
+    fun evaluer(): Regelkjøringsrapport =
+        medSpan("regelkjøring.evaluer", mapOf("regelverksdato" to regelverksdato.toString())) { span ->
+            var totalRapport: Regelkjøringsrapport? = null
+            for (dato in prøvingsperiode) {
+                val rapport = evaluerDag(dato)
+                totalRapport = totalRapport?.plus(rapport) ?: rapport
 
-            if (rapport.informasjonsbehov.isNotEmpty()) {
-                // Om en dag sier den har behov må de løses før vi kan videre til neste dag
-                break
+                if (rapport.informasjonsbehov.isNotEmpty()) {
+                    // Om en dag sier den har behov må de løses før vi kan videre til neste dag
+                    break
+                }
+            }
+
+            totalRapport!!.also { rapport ->
+                span.setAttribute("kjørteRegler", rapport.kjørteRegler.size.toLong())
+                span.setAttribute("antallDatoer", rapport.prøvingsdato.size.toLong())
+                span.setAttribute("mangler", rapport.mangler.size.toLong())
+                span.setAttribute("fjernet", rapport.fjernet.size.toLong())
+                if (rapport.prøvingsdato.size > 365) {
+                    logger.warn { "Kjørte på mer enn 365 datoer. Antall: ${rapport.prøvingsdato.size}" }
+                }
+                logger.info {
+                    """Kjørte ${rapport.kjørteRegler.size} regler for følgende datoer: ${rapport.prøvingsdato.joinToString(", ")}
+                    |Regler:
+                    |${rapport.kjørteRegler.joinToString("\n") { "- $it" }}
+                    """.trimMargin()
+                }
             }
         }
 
-        return totalRapport!!.also {
-            if (it.prøvingsdato.size > 365) {
-                logger.warn { "Kjørte på mer enn 365 datoer. Antall: ${it.prøvingsdato.size}" }
+    private fun evaluerDag(prøvingsdato: LocalDate): Regelkjøringsrapport =
+        medSpan("regelkjøring.evaluerDag", mapOf("prøvingsdato" to prøvingsdato.toString())) { span ->
+            val (kjøreplan, regelresultater) = planleggOgUtfør(prøvingsdato)
+
+            val kjørteRegler = regelresultater.flatten().map { it.regel }.toSet()
+
+            // Fjern utledede opplysninger som ikke brukes for å produsere ønsket resultat.
+            // Guard: Ikke fjern opplysninger når det finnes uløste informasjonsbehov, fordi
+            // ønsketResultat kan være ufullstendig (regelsett med skalKjøres=false pga manglende data).
+            if (kjøreplan.siste.eksterneRegler.isEmpty()) {
+                val brukteOpplysninger = avhengighetsgraf.nødvendigeOpplysninger(opplysninger, kjøreplan.siste.ønsketResultat)
+                opplysninger.fjernHvis {
+                    val opplysningFraSaksbehandler = it.kilde is Saksbehandlerkilde
+                    val opplysningFraHendelse = it.kilde is Systemkilde
+                    val trengsIkke = it.opplysningstype !in brukteOpplysninger
+                    val tilhørerDenneRegelkjøringen = it.gyldighetsperiode.fraOgMed >= prøvingsdato || it.behandletVed == prøvingsdato
+
+                    if (opplysningFraSaksbehandler || opplysningFraHendelse) return@fjernHvis false
+
+                    trengsIkke && tilhørerDenneRegelkjøringen
+                }
             }
-            logger.info {
-                """Kjørte ${it.kjørteRegler.size} regler for følgende datoer: ${it.prøvingsdato.joinToString(", ")}
-                |Regler:
-                |${it.kjørteRegler.joinToString("\n") { "- $it" }}
-                """.trimMargin()
-            }
-        }
-    }
 
-    private fun evaluerDag(prøvingsdato: LocalDate): Regelkjøringsrapport {
-        val (kjøreplan, regelresultater) = planleggOgUtfør(prøvingsdato)
+            opplysninger.markerBehandlet(prøvingsdato)
 
-        val kjørteRegler = regelresultater.flatten().map { it.regel }.toSet()
+            span.setAttribute("kjørteRegler", kjørteRegler.size.toLong())
+            span.setAttribute("iterasjoner", regelresultater.size.toLong())
 
-        // Fjern utledede opplysninger som ikke brukes for å produsere ønsket resultat.
-        // Guard: Ikke fjern opplysninger når det finnes uløste informasjonsbehov, fordi
-        // ønsketResultat kan være ufullstendig (regelsett med skalKjøres=false pga manglende data).
-        if (kjøreplan.siste.eksterneRegler.isEmpty()) {
-            val brukteOpplysninger = avhengighetsgraf.nødvendigeOpplysninger(opplysninger, kjøreplan.siste.ønsketResultat)
-            opplysninger.fjernHvis {
-                val opplysningFraSaksbehandler = it.kilde is Saksbehandlerkilde
-                val opplysningFraHendelse = it.kilde is Systemkilde
-                val trengsIkke = it.opplysningstype !in brukteOpplysninger
-                val tilhørerDenneRegelkjøringen = it.gyldighetsperiode.fraOgMed >= prøvingsdato || it.behandletVed == prøvingsdato
-
-                if (opplysningFraSaksbehandler || opplysningFraHendelse) return@fjernHvis false
-
-                trengsIkke && tilhørerDenneRegelkjøringen
-            }
-        }
-
-        opplysninger.markerBehandlet(prøvingsdato)
-
-        return Regelkjøringsrapport(
-            kjørteRegler = kjørteRegler,
-            mangler = kjøreplan.siste.trenger,
-            informasjonsbehov = kjøreplan.siste.informasjonsbehov(gjeldendeRegler),
-            fjernet = opplysninger.fjernet(),
-            prøvingsdato = listOf(prøvingsdato),
-        ).also { rapport ->
-            observatører.forEach { observer ->
-                val aktiveOpplysninger = opplysninger.kunEgne.forDato(prøvingsdato)
-                observer.evaluert(
-                    rapport,
-                    opplysninger,
-                    aktiveOpplysninger,
-                )
+            Regelkjøringsrapport(
+                kjørteRegler = kjørteRegler,
+                mangler = kjøreplan.siste.trenger,
+                informasjonsbehov = kjøreplan.siste.informasjonsbehov(gjeldendeRegler),
+                fjernet = opplysninger.fjernet(),
+                prøvingsdato = listOf(prøvingsdato),
+            ).also { rapport ->
+                observatører.forEach { observer ->
+                    val aktiveOpplysninger = opplysninger.kunEgne.forDato(prøvingsdato)
+                    observer.evaluert(rapport, opplysninger, aktiveOpplysninger)
+                }
             }
         }
-    }
 
     private class Kjøreplan(
         val siste: Regelkjøringstilstand,


### PR DESCRIPTION
Instrumenterer den uinstrumenterte personHandler-blokken (194ms svart boks i trace) med spans som viser hvor tid brukes under OmgjøringsBehandling.

Nye spans:
- person.håndter.hendelse — skiller hendelseskjøring fra observatør-registrering
- regelkjøring.evaluer — total regelkjøringstid med attributter (kjørteRegler, antallDatoer, mangler, fjernet)
- regelkjøring.evaluerDag — per-dag-kjøring med iterasjonsantall
- forretningsprosess.kjørUnderOpprettelse/kjørEtterRegelkjøring/kjørRegelkjøringFerdig
- @WithSpan på RettighetsperiodePlugin, OmgjøringBeregningPlugin og MeldekortBeregningPlugin.regelkjøringFerdig

Implementert via medSpan()-hjelpefunksjon i Regelkjøring og Forretningsprosess for å holde telemetri-boilerplate atskilt fra forretningslogikken.

Legger til opentelemetry-api og -annotations som avhengighet i opplysninger-modulen.