### PR TITLE
Legg til GET /sak/{sakId}-endepunkt

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/api/BehandlingApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/api/BehandlingApi.kt
@@ -152,6 +152,22 @@ internal fun Application.behandlingApi(
         }
 
         authenticate("azureAd") {
+            route("sak/{sakId}") {
+                get {
+                    val sakId = call.sakId
+                    val rot = personRepository.hentBehandling(sakId) ?: throw NotFoundException("Sak ikke funnet")
+                    if (rot.basertPå != null) throw NotFoundException("Sak ikke funnet")
+
+                    auditlogg.les("Så en sak", rot.behandler.ident, call.saksbehandlerId())
+
+                    val kjede =
+                        personRepository
+                            .hentBehandlinger(rot.behandler.ident.tilPersonIdentfikator())
+                            .single { it.rot.behandlingId == sakId }
+
+                    call.respond(HttpStatusCode.OK, tilSakDTO(sakId, kjede))
+                }
+            }
             route("person/rettighetsstatus") {
                 post {
                     val identForespørsel = call.receive<IdentForesporselDTO>()
@@ -831,6 +847,12 @@ private val ApplicationCall.behandlingId: UUID
     get() {
         val behandlingId = parameters["behandlingId"] ?: throw IllegalArgumentException("BehandlingId må være satt")
         return UUID.fromString(behandlingId)
+    }
+
+private val ApplicationCall.sakId: UUID
+    get() {
+        val sakId = parameters["sakId"] ?: throw IllegalArgumentException("SakId må være satt")
+        return UUID.fromString(sakId)
     }
 
 private val ApplicationCall.avklaringId: UUID

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/api/SakMapper.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/api/SakMapper.kt
@@ -1,0 +1,66 @@
+package no.nav.dagpenger.mediator.api
+
+import no.nav.dagpenger.mediator.api.models.BehandlingSammendragDTO
+import no.nav.dagpenger.mediator.api.models.PeriodeDTO
+import no.nav.dagpenger.mediator.api.models.SakDTO
+import no.nav.dagpenger.mediator.api.models.SakStatusDTO
+import no.nav.dagpenger.modell.Behandling
+import no.nav.dagpenger.modell.Behandling.TilstandType.Ferdig
+import no.nav.dagpenger.modell.Behandlingkjede
+import no.nav.dagpenger.regel.regelsett.beregning.Beregning
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Bygger en SakDTO direkte fra en fullt hydrert Behandlingkjede. Dette er bevisst enkelt:
+ * hele kjeden hentes og hydreres på vanlig måte (samme vei som GET /behandling/v2), uten egne
+ * spørringer eller lesemodeller. Om dette blir en ytelsesutfordring for lange kjeder, bør det
+ * håndteres som en egen, separat optimalisering.
+ */
+internal fun tilSakDTO(
+    sakId: UUID,
+    kjede: Behandlingkjede,
+): SakDTO =
+    SakDTO(
+        sakId = sakId,
+        status = kjede.nesteSomKanBaseresPå?.tilSakStatusDTO() ?: SakStatusDTO(harLøpendeRett = false),
+        // Nyeste behandling først, i tråd med hvordan behandlingskjeder presenteres i POST /behandling
+        behandlinger = kjede.toList().reversed().map { it.tilBehandlingSammendragDTO() },
+    )
+
+private fun Behandling.tilBehandlingSammendragDTO(): BehandlingSammendragDTO =
+    BehandlingSammendragDTO(
+        behandlingId = behandlingId,
+        opprettet = opprettet,
+        ferdigstilt = sistEndret.takeIf { harTilstand(Ferdig) },
+        behandletHendelse = behandler.tilHendelseDTO(),
+        førteTil = takeIf { harTilstand(Ferdig) }?.vedtakopplysninger?.avgjørelse?.tilAvgjørelseDTO(),
+    )
+
+private fun Behandling.tilSakStatusDTO(): SakStatusDTO {
+    val opplysninger = opplysninger()
+    val perioder = vedtakopplysninger.rettighetsperioderRådata()
+    val iDag = LocalDate.now()
+    val gjeldendePeriode =
+        perioder.lastOrNull { !it.fraOgMed.isAfter(iDag) && !it.tilOgMed.isBefore(iDag) }
+
+    val sisteMeldeperiode =
+        opplysninger
+            .finnAlle(Beregning.meldeperiode)
+            .maxByOrNull { it.verdi.tilOgMed }
+            ?.verdi
+
+    return SakStatusDTO(
+        harLøpendeRett = gjeldendePeriode?.harRett ?: false,
+        fraOgMed = gjeldendePeriode?.fraOgMed,
+        tilOgMed = gjeldendePeriode?.tilOgMed?.tilApiDato(),
+        sisteMeldeperiode = sisteMeldeperiode?.let { PeriodeDTO(fraOgMed = it.fraOgMed, tilOgMed = it.tilOgMed) },
+        // sisteGjenståendeDager har en åpen gyldighetsperiode (fra siste forbruksdato og fremover),
+        // i motsetning til gjenståendeDager som kun er gyldig per forbruksdag
+        gjenståendeDager = opplysninger.finnNullableOpplysning(Beregning.sisteGjenståendeDager)?.verdi,
+        sistEndret = sistEndret,
+    )
+}
+
+private fun Behandling.VedtakOpplysninger.rettighetsperioderRådata() =
+    behandlingAv.forretningsprosess.regelverk.rettighetsperioder(opplysninger)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mediator/api/BehandlingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mediator/api/BehandlingApiTest.kt
@@ -21,6 +21,7 @@ import no.nav.dagpenger.dato.april
 import no.nav.dagpenger.mediator.api.TestApplication.maskinToken
 import no.nav.dagpenger.mediator.api.TestApplication.testAzureAdToken
 import no.nav.dagpenger.mediator.api.TestApplication.withMockAuthServerAndTestApplication
+import no.nav.dagpenger.mediator.api.models.AvgjørelseDTO
 import no.nav.dagpenger.mediator.api.models.BehandlingDTO
 import no.nav.dagpenger.mediator.api.models.BehandlingsresultatDTO
 import no.nav.dagpenger.mediator.api.models.DesimaltallVerdiDTO
@@ -29,6 +30,7 @@ import no.nav.dagpenger.mediator.api.models.FerietilleggKvitteringDTO
 import no.nav.dagpenger.mediator.api.models.HendelseDTOTypeDTO
 import no.nav.dagpenger.mediator.api.models.OpplysningerDTO
 import no.nav.dagpenger.mediator.api.models.OpplysningstypeDTO
+import no.nav.dagpenger.mediator.api.models.SakDTO
 import no.nav.dagpenger.mediator.api.models.SaksbehandlersVurderingerDTO
 import no.nav.dagpenger.mediator.asUUID
 import no.nav.dagpenger.mediator.januar
@@ -273,6 +275,45 @@ internal class BehandlingApiTest {
                     HendelseDTOTypeDTO.MELDEKORT,
                     HendelseDTOTypeDTO.SØKNAD,
                 )
+        }
+    }
+
+    @Test
+    fun `hent sak gitt en behandlingskjedeId`() {
+        medSikretBehandlingApi { testContext ->
+            person.søkDagpenger(1.april(LocalDate.now().year))
+            behovsløsere.løsTilForslag()
+            saksbehandler.lukkAlleAvklaringer()
+            saksbehandler.godkjenn()
+            saksbehandler.beslutt()
+
+            val sakId = person.behandling.behandlingskjedeId
+
+            val response = testContext.autentisert(httpMethod = HttpMethod.Get, endepunkt = "/sak/$sakId")
+            response.status shouldBe HttpStatusCode.OK
+
+            val sak = response.body<SakDTO>()
+            sak.sakId shouldBe sakId
+            sak.status.harLøpendeRett shouldBe true
+            sak.behandlinger shouldHaveSize 1
+            sak.behandlinger.single().behandlingId shouldBe person.behandlingId
+            sak.behandlinger
+                .single()
+                .behandletHendelse.type shouldBe HendelseDTOTypeDTO.SØKNAD
+            sak.behandlinger
+                .single()
+                .ferdigstilt
+                .shouldNotBeNull()
+            sak.behandlinger.single().førteTil shouldBe AvgjørelseDTO.INNVILGELSE
+        }
+    }
+
+    @Test
+    fun `gir 404 for ukjent sak`() {
+        medSikretBehandlingApi { testContext ->
+            val response =
+                testContext.autentisert(httpMethod = HttpMethod.Get, endepunkt = "/sak/${UUIDv7.ny()}")
+            response.status shouldBe HttpStatusCode.NotFound
         }
     }
 

--- a/mediator/src/test/resources/no/nav/dagpenger/mediator/api/BehandlingApiTest.hent sak gitt en behandlingskjedeId.approved.txt
+++ b/mediator/src/test/resources/no/nav/dagpenger/mediator/api/BehandlingApiTest.hent sak gitt en behandlingskjedeId.approved.txt
@@ -1,0 +1,46 @@
+Laget avklaring om HarTilleggsopplysninger
+Opprettet ny behandling
+Behandling endret tilstand til: UnderBehandling
+Behov:
+- Fødselsdato
+- ØnskerDagpengerFraDato
+Laget avklaring om HattLukkedeSakerSiste8Uker
+Laget avklaring om MuligGjenopptak
+Behov:
+- HelseTilAlleTyperJobb
+- Inntekt
+- KanJobbeDeltid
+- KanJobbeHvorSomHelst
+- Lønnsgaranti
+- Ordinær
+- Permittert
+- PermittertFiskeforedling
+- RegistrertSomArbeidssøker
+- Verneplikt
+- VilligTilÅBytteYrke
+- ØnsketArbeidstid
+Laget avklaring om EØSArbeid
+Laget avklaring om InntektNesteKalendermåned
+Laget avklaring om JobbetUtenforNorge
+Laget avklaring om BeregnetArbeidstid
+Behov:
+- AndreØkonomiskeYtelser
+- BostedslandErNorge
+- ErUtestengt
+- Foreldrepenger
+- Omsorgspenger
+- Opplæringspenger
+- Pleiepenger
+- Svangerskapspenger
+- Sykepenger
+- TarUtdanningEllerOpplæring
+- Uføre
+Laget avklaring om SjekkPrøvingsdato
+Behov:
+- BarnetilleggV2
+- OppgittAndreYtelserUtenforNav
+Laget avklaring om BarnMåGodkjennes
+Behandling endret tilstand til: ForslagTilVedtak
+Behandling endret tilstand til: TilGodkjenning
+Behandling endret tilstand til: TilBeslutning
+Behandling endret tilstand til: Ferdig

--- a/openapi/src/main/resources/behandling-api.yaml
+++ b/openapi/src/main/resources/behandling-api.yaml
@@ -15,6 +15,8 @@ tags:
     description: Operasjoner på opplysningstyper.
   - name: Person
     description: Operasjoner på person.
+  - name: Sak
+    description: Operasjoner på saker (behandlingskjeder).
   - name: Behandling
     description: Operasjoner på behandlinger.
   - name: Avklaring
@@ -93,6 +95,35 @@ paths:
                 $ref: '#/components/schemas/Behandling'
         default:
           description: Feil ved oppretting av behandling
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HttpProblem'
+
+  /sak/{sakId}:
+    parameters:
+      - name: sakId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+        description: Sakens id. Dette tilsvarer behandlingskjedeId, altså en sammenhengende rettighetsperiode.
+    get:
+      summary: Hent status og behandlingshistorikk for en sak
+      security:
+        - azureAd: [ ]
+      tags:
+        - Sak
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sak'
+          description: OK
+        default:
+          description: Feil ved henting av sak
           content:
             application/problem+json:
               schema:
@@ -2170,6 +2201,75 @@ components:
           $ref: '#/components/schemas/BehandlingId'
         behandlingskjedeId:
           $ref: '#/components/schemas/BehandlingId'
+
+    Sak:
+      description: En sak, det vil si en sammenhengende behandlingskjede med tilhørende status og behandlingshistorikk
+      type: object
+      required:
+        - sakId
+        - status
+        - behandlinger
+      properties:
+        sakId:
+          $ref: '#/components/schemas/BehandlingId'
+        status:
+          $ref: '#/components/schemas/SakStatus'
+        behandlinger:
+          description: Alle behandlinger i saken, i kjedet rekkefølge (nyeste først)
+          type: array
+          items:
+            $ref: '#/components/schemas/BehandlingSammendrag'
+
+    SakStatus:
+      description: Gjeldende status for saken, basert på siste ferdigstilte behandling
+      type: object
+      required:
+        - harLøpendeRett
+      properties:
+        harLøpendeRett:
+          description: Om bruker har en løpende rett på dagpenger i dag
+          type: boolean
+        fraOgMed:
+          description: Fra og med dato for gjeldende rettighetsperiode
+          type: string
+          format: date
+        tilOgMed:
+          description: Til og med dato for gjeldende rettighetsperiode, hvis den er avsluttet
+          type: string
+          format: date
+        sisteMeldeperiode:
+          $ref: '#/components/schemas/Periode'
+        gjenståendeDager:
+          description: Antall gjenstående dager med rett på dagpenger
+          type: integer
+        sistEndret:
+          description: Tidspunktet siste ferdigstilte behandling i saken ble ferdig
+          type: string
+          format: date-time
+
+    BehandlingSammendrag:
+      description: En tynn representasjon av en behandling i en behandlingskjede
+      type: object
+      required:
+        - behandlingId
+        - opprettet
+        - behandletHendelse
+      properties:
+        behandlingId:
+          $ref: '#/components/schemas/BehandlingId'
+        opprettet:
+          type: string
+          format: date-time
+        ferdigstilt:
+          description: Tidspunktet behandlingen ble ferdigstilt, hvis den er ferdig
+          type: string
+          format: date-time
+        behandletHendelse:
+          description: Hvilken hendelse som utløste behandlingen
+          $ref: '#/components/schemas/Hendelse'
+        førteTil:
+          $ref: '#/components/schemas/Avgjørelse'
+          description: Hvilken avgjørelse behandlingen førte til, hvis den er ferdig
 
     VilkaarNavn:
       type: string


### PR DESCRIPTION
Nytt endepunkt som viser gjeldende status (løpende rett, gyldighetsperiode, siste meldeperiode, gjenstående dager, sist endret) samt en tynn, kjedet liste over alle behandlinger i saken (behandlingId, opprettet, ferdigstilt, behandletHendelse, førteTil) - i tråd med rekkefølgen brukt i POST /behandling.

Implementasjonen gjenbruker eksisterende PersonRepository.hentBehandling og hentBehandlinger for å bygge kjeden, samt Behandlingkjede.nesteSomKanBaseresPå for å finne gjeldende vedtak. Ingen endringer i repository-laget eller databaseskjema - dataredusering skjer i API-kontrakten, ikke i spørringen. Full hydrering av behandlingskjeden aksepteres som en bevisst, midlertidig avveining; en lesemodell-optimalisering kan gjøres senere uten å endre kontrakten.