### PR TITLE
Optimaliser rekursiv CTE for opplysninger: traverser grunntabeller direkte

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/mediator/repository/OpplysningerRepositoryPostgres.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mediator/repository/OpplysningerRepositoryPostgres.kt
@@ -151,24 +151,38 @@ internal class OpplysningerRepositoryPostgres(
                         queryOf(
                             //language=PostgreSQL
                             """
-                            with recursive 
-                                opplysningskjede as (
+                            WITH RECURSIVE
+                                opplysningskjede AS (
                                     -- ankeropplysninger
-                                    select id, utledet_av_id, erstatter_id
-                                    from opplysningstabell
-                                    where opplysninger_id = ANY(:opplysninger_ider)
+                                    SELECT id, erstatter_id
+                                    FROM opplysning
+                                    WHERE opplysninger_id = ANY(:opplysninger_ider) AND fjernet IS FALSE
                                     
-                                    union
-                                    -- rekursive opplysninger
-                                    select o.id, o.utledet_av_id, o.erstatter_id
-                                    from opplysningstabell o
-                                    join opplysningskjede ok on o.id = any(ok.utledet_av_id) or o.id = ok.erstatter_id
-                                ),
-                                kjede_ids as (select distinct id from opplysningskjede)
-                            select o.*
-                            from kjede_ids k
-                            join opplysningstabell o on o.id = k.id
-                            order by o.id
+                                    UNION
+                                    -- rekursive opplysninger. Traverserer grunntabellene direkte (ikke
+                                    -- opplysningstabell-viewet) for å unngå å betale for viewets to
+                                    -- LATERAL-subqueries på hvert rekursjonsnivå. Viewet trengs bare
+                                    -- for sluttresultatet.
+                                    SELECT o.id, o.erstatter_id
+                                    FROM opplysningskjede ok
+                                    CROSS JOIN LATERAL (
+                                        SELECT utledet_av AS ref_id
+                                        FROM opplysning_utledet_av
+                                        WHERE opplysning_id = ok.id
+                                        UNION ALL
+                                        SELECT ok.erstatter_id
+                                        WHERE ok.erstatter_id IS NOT NULL
+                                    ) cand
+                                    JOIN opplysning o ON o.id = cand.ref_id AND o.fjernet IS FALSE
+                                )
+                            -- Array-basert oppslag (i stedet for join mot CTE-en) fordi rekursive
+                            -- CTE-er har dårlige radestimater i Postgres. Et join mot opplysningskjede
+                            -- direkte fikk planleggeren til å tro resultatet var mye større enn det er,
+                            -- og valgte en full tabellskann (Merge Join) i stedet for indeksoppslag.
+                            SELECT o.*
+                            FROM opplysningstabell o
+                            WHERE o.id = ANY(ARRAY(SELECT id FROM opplysningskjede))
+                            ORDER BY o.id
                             """.trimIndent(),
                             mapOf(
                                 "opplysninger_ider" to


### PR DESCRIPTION
## Hva

Rekursjonen i `hentOpplysninger` (hentOpplysningskjede-spørringen) traverserte tidligere `opplysningstabell`-viewet, som per rad betaler for to `LATERAL`-subqueries. Ved produksjonsskala ga OR-betingelsen i rekursjonen i tillegg en katastrofal plan der hele `opplysning`-tabellen ble skannet på nytt for hver rad i arbeidstabellen.

To endringer:
1. Rekursjonen traverserer nå grunntabellene (`opplysning` + `opplysning_utledet_av`) direkte i stedet for viewet. Viewet joines kun én gang, for sluttresultatet.
2. Sluttspørringen bruker et array-basert oppslag (`o.id = any(array(select id from opplysningskjede))`) i stedet for å joine direkte mot CTE-en, som unngår Postgres' notorisk dårlige radestimater for rekursive CTE-er (som ellers trigget en full tabellskann/Merge Join).

## Verifisering

- Identisk resultatsett som original spørring (lokalt og i dev).
- Lokal skala-test (1M rader, syntetisk padding): ~125x raskere enn original (30.7s → 244ms).
- Reell dev-data (421 119 rader i `opplysning`, reell 1354-node kjede): 282.7ms → 24.5-34.5ms (8-11x raskere).
- Shadow-sammenlignet mot original spørring på reell dev-trafikk over tid: identiske resultatsett, ingen avvik.
- Full `:mediator:test`-suite og `ktlintCheck` grønt.

## Bakgrunn

Historikken på denne branchen er squashet til én commit for å unngå å ta med iterasjonsrundene (dev-deploy-toggling, shadow-sammenligning som ble lagt til og fjernet igjen etter verifisering).