### PR TITLE
perf: batch leggTil-kall i meldekortberegning for å redusere cache-re…

### DIFF
--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/Kvotetelling.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/Kvotetelling.kt
@@ -58,10 +58,14 @@ class KvotetellingsSkriver(
         opplysninger: Opplysninger,
         resultat: Kvotetellingsresultat,
     ) {
-        resultat.forbruktTeller.forEach { opplysninger.leggTil(Faktum(definisjon.forbruksteller, it.verdi, it.gyldighetsperiode)) }
-        resultat.gjenstående.forEach { opplysninger.leggTil(Faktum(definisjon.gjenstående, it.verdi, it.gyldighetsperiode)) }
-        resultat.sisteDagMedForbruk?.let { opplysninger.leggTil(Faktum(definisjon.sisteForbruk, it.verdi, it.gyldighetsperiode)) }
-        resultat.sisteGjenstående?.let { opplysninger.leggTil(Faktum(definisjon.sisteGjenstående, it.verdi, it.gyldighetsperiode)) }
+        val batch =
+            buildList {
+                resultat.forbruktTeller.forEach { add(Faktum(definisjon.forbruksteller, it.verdi, it.gyldighetsperiode)) }
+                resultat.gjenstående.forEach { add(Faktum(definisjon.gjenstående, it.verdi, it.gyldighetsperiode)) }
+                resultat.sisteDagMedForbruk?.let { add(Faktum(definisjon.sisteForbruk, it.verdi, it.gyldighetsperiode)) }
+                resultat.sisteGjenstående?.let { add(Faktum(definisjon.sisteGjenstående, it.verdi, it.gyldighetsperiode)) }
+            }
+        opplysninger.leggTilAlle(batch)
 
         if (resultat.sisteGjenstående?.verdi == 0 && resultat.gjenstående.any { it.verdi != 0 }) {
             val sisteDag = resultat.sisteDagMedForbruk!!.verdi

--- a/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/MeldekortBeregningPlugin.kt
+++ b/dagpenger/src/main/kotlin/no/nav/dagpenger/regel/prosess/MeldekortBeregningPlugin.kt
@@ -64,13 +64,16 @@ class MeldekortBeregningPlugin(
         opplysninger.leggTil(Faktum(oppfyllerKravTilTaptArbeidstidIPerioden, resultat.oppfyllerKravTilTaptArbeidstid, gyldighetsperiode))
 
         val forbruksdager = resultat.beregningsdager
-        forbruksdager
-            .forEach { dag ->
+        val dagOpplysninger =
+            forbruksdager.flatMap { dag ->
                 val dagGyldighetsperiode = dag.gyldighetsperiode
-                opplysninger.leggTil(Faktum(forbruk, dag is Forbruksdag, dagGyldighetsperiode))
-                opplysninger.leggTil(Faktum(utbetaling, dag.tilUtbetaling, dagGyldighetsperiode))
-                opplysninger.leggTil(Faktum(erSanksjonsdag, dag.avviklerSanksjon, dagGyldighetsperiode))
+                listOf(
+                    Faktum(forbruk, dag is Forbruksdag, dagGyldighetsperiode),
+                    Faktum(utbetaling, dag.tilUtbetaling, dagGyldighetsperiode),
+                    Faktum(erSanksjonsdag, dag.avviklerSanksjon, dagGyldighetsperiode),
+                )
             }
+        opplysninger.leggTilAlle(dagOpplysninger)
 
         Kvoteteller(kvoter, resultat.beregningsdager)
             .beregn(opplysninger, meldeperiode.fraOgMed)

--- a/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysninger.kt
+++ b/opplysninger/src/main/kotlin/no/nav/dagpenger/opplysning/Opplysninger.kt
@@ -29,11 +29,21 @@ class Opplysninger private constructor(
     override val kunEgne: LesbarOpplysninger get() = OpplysningerView(this, bareEgne = true)
 
     private fun refreshOpplysninger() {
-        alleOpplysninger.refresh()
-        alleOpplysningerMap = alleOpplysninger.groupBy { it.opplysningstype }
+        val oppfrisketOpplysninger = alleOpplysninger.refresh()
+        alleOpplysningerMap = oppfrisketOpplysninger.groupBy { it.opplysningstype }
     }
 
     fun <T : Any> leggTil(opplysning: Opplysning<T>) {
+        leggTilIntern(opplysning)
+        refreshOpplysninger()
+    }
+
+    fun leggTilAlle(opplysninger: List<Opplysning<*>>) {
+        opplysninger.forEach { leggTilIntern(it) }
+        refreshOpplysninger()
+    }
+
+    private fun <T : Any> leggTilIntern(opplysning: Opplysning<T>) {
         opplysning.behandlet = false
         opplysning.behandletVed = null
         val eksisterende = finnNullableOpplysning(opplysning.opplysningstype, opplysning.gyldighetsperiode)
@@ -59,7 +69,6 @@ class Opplysninger private constructor(
         }
 
         egne.add(opplysning)
-        refreshOpplysninger()
     }
 
     private fun markerUtledningerSomUtdatert(eksisterende: Opplysning<*>) {


### PR DESCRIPTION
…builds

Hvert kall til leggTil() trigget refreshOpplysninger() som er O(N log N). Med 14 meldeperioder og ~140 leggTil-kall per periode ga dette ~1960 unødvendige rebuilds av alleOpplysningerMap — kvadratisk vekst som forklarer hvorfor senere perioder er merkbart tregere enn de første.

- Legg til Opplysninger.leggTilAlle() som batcher N opplysninger og refresher kun én gang til slutt. Forutsetter ferske gyldighetsperioder som ikke erstatter eksisterende opplysninger.
- Bruk leggTilAlle() i KvotetellingsSkriver.skriv() (~30 kall → 1 per kvote)
- Bruk leggTilAlle() i MeldekortBeregningPlugin for dagloopen (42 kall → 1)
- refreshOpplysninger() bruker nå den returnerte listen fra refresh() direkte i stedet for å lese CachedList via getteren på nytt

Forventet effekt: ~140 → ~12 rebuilds per meldeperiode, totalt ~10 sek → ~1 sek for re-beregning av 14 meldeperioder ved omgjøring.

refactor: leggTilIntern-lambda

Trekker ut leggTilIntern() som håndterer erstatter-logikk og muterer egne uten å refreshe. leggTil() og leggTilAlle() kaller denne og refreshOpplysninger() eksplisitt én gang til slutt.